### PR TITLE
Upgrade default to .NET Core 3.1

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -3,7 +3,7 @@
 
 parameters:
   # Default values
-  dotNetCoreVersion: '2.2.107' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
+  dotNetCoreVersion: '3.1.102' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
   useVersionSuffix: true
   restoreDependencies: false
   nuGetServiceConnections: #required when restoreDependies = true

--- a/publish-plugin.yml
+++ b/publish-plugin.yml
@@ -4,7 +4,7 @@
 parameters:
   pool: {}
   useVersionSuffix: true
-  dotNetCoreVersion: '2.2.107' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
+  dotNetCoreVersion: '3.1.102' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
   
 jobs:
 - job: Publish_plugin


### PR DESCRIPTION
.NET Core 2.2 is now officially deprecated. Upgrade to the new LTS version 3.1.