### PR TITLE
VONK-4777: Fix/vulnerability check ignore warnings with file

### DIFF
--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -17,6 +17,7 @@ parameters:
   displayName: 'The version of the Docker repository'
 - name: 'trivyIgnoreFile'
   type: 'string'
+  default: ''
   displayName: 'The version of the Docker repository'
 
 jobs:

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -15,7 +15,9 @@ parameters:
 - name: 'dockerImageRepoVersion'
   type: 'string'
   displayName: 'The version of the Docker repository'
-
+- name: 'trivyIgnoreFile'
+  type: 'string'
+  displayName: 'The version of the Docker repository'
 
 jobs:
 - job: scanDockerImage
@@ -37,7 +39,7 @@ jobs:
       customCommand: 'pull ${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}:${{ parameters.dockerImageRepoVersion }}'
 
   - script: | 
-      docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v $(System.DefaultWorkingDirectory):/src  aquasec/trivy:latest image --exit-code 1 --format table --scanners vuln,config,secret --severity HIGH,CRITICAL ${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}:${{ parameters.dockerImageRepoVersion }}
+      docker run --rm -v /var/run/docker.sock:/var/run/docker.sock  -v ${{ parameters.trivyIgnoreFile }}:/tmp/trivyignore aquasec/trivy:latest image --ignorefile /tmp/trivyignore --exit-code 1 --format table --scanners vuln,config,secret  ${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}:${{ parameters.dockerImageRepoVersion }}
     displayName: Scan image with Trivy
 
 #  The Trivy task does not work yet.

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -25,7 +25,7 @@ jobs:
   displayName: Scan Docker image for vulnerabilities
   dependsOn: createDockerImage
   steps:
-  - checkout: none
+  - checkout: self
   - task: Docker@2
     displayName: Login to ACR
     inputs:


### PR DESCRIPTION
Use a Trivy ignore file to ignore some specific CVEs.

When no file is given then no file is used during scanning.

See also Jira: VONK-4777