### PR TITLE
Fix/fixing trivy scan

### DIFF
--- a/scanBinaries.yml
+++ b/scanBinaries.yml
@@ -22,5 +22,5 @@ jobs:
       cleanDestinationFolder: true
       overwriteExistingFiles: false
   - script: | 
-      docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v $(System.DefaultWorkingDirectory)/Binaries:/src  aquasec/trivy:latest  --exit-code 1 --format table --scanners vuln,config,secret filesystem /src
+      docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v $(System.DefaultWorkingDirectory)/Binaries:/src  aquasec/trivy:latest  --exit-code 1 --format table --scanners vuln,misconfig,secret filesystem /src
     displayName: Scan compiled code with Trivy

--- a/scanCompiledArtifacts.yml
+++ b/scanCompiledArtifacts.yml
@@ -9,5 +9,5 @@ parameters:
 
 steps:
 - script: | 
-    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v ${{ parameters.directory }}:/src  aquasec/trivy:latest  --exit-code 1 --format table --scanners vuln,config,secret filesystem /src
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v ${{ parameters.directory }}:/src  aquasec/trivy:latest  --exit-code 1 --format table --scanners vuln,misconfig,secret filesystem /src
   displayName: Scan compiled code with Trivy

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -39,7 +39,7 @@ jobs:
       customCommand: 'pull ${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}:${{ parameters.dockerImageRepoVersion }}'
 
   - script: | 
-      docker run --rm -v /var/run/docker.sock:/var/run/docker.sock  -v ${{ parameters.trivyIgnoreFile }}:/tmp/trivyignore aquasec/trivy:latest image --ignorefile /tmp/trivyignore --exit-code 1 --format table --scanners vuln,config,secret  ${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}:${{ parameters.dockerImageRepoVersion }}
+      docker run --rm -v /var/run/docker.sock:/var/run/docker.sock  -v ${{ parameters.trivyIgnoreFile }}:/tmp/trivyignore aquasec/trivy:latest image --ignorefile /tmp/trivyignore --exit-code 1 --format table --scanners vuln,misconfig,secret  ${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}:${{ parameters.dockerImageRepoVersion }}
     displayName: Scan image with Trivy
 
 #  The Trivy task does not work yet.


### PR DESCRIPTION
There was a warning in the build logs:
`2024-09-23T13:57:48Z	WARN	'--scanners config' is deprecated. Use '--scanners misconfig' instead. See https://github.com/aquasecurity/trivy/discussions/5586 for the detail.
`

See [this build ](https://dev.azure.com/firely/vonk/_build/results?buildId=44942&view=results) for checking the updated code