### PR TITLE
Fix/fixing unit test not triggered

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -143,10 +143,19 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet test UnitTests'
+    condition: and(succeeded(), ne('${{ parameters.testFilter }}', ''))
     inputs:
       command: test
       projects: '**/*Tests/*Tests.csproj'
       arguments: '--configuration $(buildConfiguration) --no-restore --filter ${{ parameters.testFilter }}'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet test UnitTests'
+    condition: and(succeeded(), eq('${{ parameters.testFilter }}', ''))
+    inputs:
+      command: test
+      projects: '**/*Tests/*Tests.csproj'
+      arguments: '--configuration $(buildConfiguration) --no-restore'
 
   - ${{ if eq(parameters.packageArtifacts, 'true') }}:
     - template: package.yml

--- a/build.yml
+++ b/build.yml
@@ -146,7 +146,7 @@ jobs:
     inputs:
       command: test
       projects: '**/*Tests/*Tests.csproj'
-      arguments: '--configuration $(buildConfiguration) --no-restore --filter ${parameters.testFilter}'
+      arguments: '--configuration $(buildConfiguration) --no-restore --filter ${{ parameters.testFilter }}'
 
   - ${{ if eq(parameters.packageArtifacts, 'true') }}:
     - template: package.yml


### PR DESCRIPTION
Fixing the fact that no unit tests were executed if no filter is provided.
see e.g.. https://dev.azure.com/firely/vonk/_build/results?buildId=45029&view=logs&j=570c8260-3cd5-52b1-af7c-9355cae40a57&t=9a203434-9143-5dd5-3d7a-0189b4cf47a0
```
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
No test matches the given testcase filter '${parameters testFilter}' in D:\a\1\5\test\Firely.Auth.Core.Tests\bin\Release\net8.0\Firely.Auth.Core.Tests.dll
Results File: D: \aL_temp\VssAdministrator_Fv-az294-820_2024-09-25_09_04_28.trx
```
