### PR TITLE
DEVOPS-366 Enhance build configuration for submodules and solution files

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -86,6 +86,11 @@ jobs:
     inputs:
       version: ${{ parameters.dotNetCoreVersion }}
 
+  - ${{ if parameters.checkoutSubmodules }}:
+    # enable long paths, especially on submodules
+    - script: git config --system core.longpaths true
+      displayName: 'Enable long paths for git'
+
   - checkout: self
     submodules: '{{ parameters.checkoutSubmodules }}'
 

--- a/build.yml
+++ b/build.yml
@@ -104,7 +104,7 @@ jobs:
       displayName: 'Enable long paths for git'
 
   - checkout: self
-    submodules: '{{ parameters.checkoutSubmodules }}'
+    submodules: ${{ parameters.checkoutSubmodules }}
 
   ## retrieve the version suffix from the props file and set it as a variable
   - powershell: |

--- a/build.yml
+++ b/build.yml
@@ -213,7 +213,7 @@ jobs:
     inputs:
       command: test
       projects: ${{ parameters.testProjects }}
-      arguments: '--configuration $(buildConfiguration) --no-restore --filter ${{ parameters.testFilter }}'
+      arguments: '--configuration $(buildConfiguration) --no-restore  --no-build --filter ${{ parameters.testFilter }}'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet test UnitTests'
@@ -221,7 +221,7 @@ jobs:
     inputs:
       command: test
       projects: ${{ parameters.testProjects }}
-      arguments: '--configuration $(buildConfiguration) --no-restore'
+      arguments: '--configuration $(buildConfiguration) --no-restore  --no-build'
 
   - template: strongNameSigning.yml
     parameters:

--- a/build.yml
+++ b/build.yml
@@ -44,6 +44,10 @@ parameters:
 - name: pool
   type: object
   default: {} # pool to use for the build
+- name: testProjects
+  type: string
+  default: '**/*Tests/*Tests.csproj'
+  displayName: 'Test projects to run'
 - name: testFilter
   type: string
   default: '' # filter for unit tests; all tests by default
@@ -77,6 +81,14 @@ parameters:
   type: string
   default: ''
   displayName: 'Password for the code signing certificate'
+- name: buildSolutionFile
+  type: string
+  default: ''
+  displayName: 'Solution file to build. If empty, the default solution file in the working directory will be used'
+- name: packageSolutionFile
+  type: string
+  default: ''
+  displayName: 'Solution file to package. If empty, the default solution file in the working directory will be used'
 
 jobs:
 - job: Build
@@ -151,11 +163,11 @@ jobs:
       nuGetServiceConnections: ${{ parameters.nuGetServiceConnections }}
       nuGetSources: ${{ parameters.nuGetSources }}
       
-  - script: dotnet build --configuration $(buildConfiguration) --no-restore
+  - script: dotnet build ${{ parameters.buildSolutionFile }} --configuration $(buildConfiguration) --no-restore /p:ContinuousIntegrationBuild=true
     displayName: 'dotnet build $(buildConfiguration)'
     condition: and(succeeded(), eq(variables.UseVersionSuffix, 'false'))
 
-  - script: dotnet build --configuration $(buildConfiguration) --version-suffix $(VersionSuffix) --no-restore
+  - script: dotnet build ${{ parameters.buildSolutionFile }} --configuration $(buildConfiguration) --version-suffix $(VersionSuffix) --no-restore /p:ContinuousIntegrationBuild=true
     displayName: 'dotnet build $(buildConfiguration) with version suffix'
     condition: and(succeeded(), eq(variables.UseVersionSuffix, 'true'))
 
@@ -200,7 +212,7 @@ jobs:
     condition: and(succeeded(), ne('${{ parameters.testFilter }}', ''))
     inputs:
       command: test
-      projects: '**/*Tests/*Tests.csproj'
+      projects: ${{ parameters.testProjects }}
       arguments: '--configuration $(buildConfiguration) --no-restore --filter ${{ parameters.testFilter }}'
 
   - task: DotNetCoreCLI@2
@@ -208,7 +220,7 @@ jobs:
     condition: and(succeeded(), eq('${{ parameters.testFilter }}', ''))
     inputs:
       command: test
-      projects: '**/*Tests/*Tests.csproj'
+      projects: ${{ parameters.testProjects }}
       arguments: '--configuration $(buildConfiguration) --no-restore'
 
   - template: strongNameSigning.yml
@@ -226,6 +238,7 @@ jobs:
         versionSuffix: $(VersionSuffix)
         codeSignerCertificate: ${{ parameters.codeSignerCertificate }}
         codeSignerPassword: ${{ parameters.codeSignerPassword }}
+        packageSolutionFile: ${{ parameters.packageSolutionFile }}
   
   - ${{ if parameters.publishArtifacts }}:
     - template: publish.yml

--- a/build.yml
+++ b/build.yml
@@ -39,8 +39,8 @@ parameters:
   type: boolean
   default: false # if true, the published artifacts will be zipped
 - name: checkoutSubmodules
-  type: boolean
-  default: false # if true, submodules will be checked out
+  type: string
+  default: 'false' # if 'true', submodules will be checked out, 'recursive' will also check out submodules of submodules
 - name: pool
   type: object
   default: {} # pool to use for the build
@@ -98,13 +98,13 @@ jobs:
     inputs:
       version: ${{ parameters.dotNetCoreVersion }}
 
-  - ${{ if parameters.checkoutSubmodules }}:
+  - ${{ if ne(parameters.checkoutSubmodules, 'false') }}:
     # enable long paths, especially on submodules
     - script: git config --system core.longpaths true
       displayName: 'Enable long paths for git'
 
   - checkout: self
-    submodules: '{{ parameters.checkoutSubmodules }}'
+    submodules: {{ parameters.checkoutSubmodules }}
 
   ## retrieve the version suffix from the props file and set it as a variable
   - powershell: |

--- a/build.yml
+++ b/build.yml
@@ -40,7 +40,8 @@ parameters:
   default: false # if true, the published artifacts will be zipped
 - name: checkoutSubmodules
   type: string
-  default: 'false' # if 'true', submodules will be checked out, 'recursive' will also check out submodules of submodules
+  default: 'false'
+  displayName: 'if "true", submodules will be checked out, "recursive" will also check out submodules of submodules'
 - name: pool
   type: object
   default: {} # pool to use for the build

--- a/build.yml
+++ b/build.yml
@@ -104,7 +104,7 @@ jobs:
       displayName: 'Enable long paths for git'
 
   - checkout: self
-    submodules: {{ parameters.checkoutSubmodules }}
+    submodules: '{{ parameters.checkoutSubmodules }}'
 
   ## retrieve the version suffix from the props file and set it as a variable
   - powershell: |

--- a/package.yml
+++ b/package.yml
@@ -20,6 +20,10 @@ parameters:
   type: string
   default: ''
   displayName: 'Password for the code signing certificate'
+- name: packageSolutionFile
+  type: string
+  default: ''
+  displayName: 'Solution file to package. If empty, the default solution file in the working directory will be used'
 
 steps:
   - powershell: |
@@ -55,11 +59,11 @@ steps:
     displayName: 'Determine version suffix use for packaging'
 
   # Package nugets
-  - script: dotnet pack --no-build --configuration $(buildConfiguration) --version-suffix $(VersionSuffixPackage) --output $(Build.artifactStagingDirectory)/packages
+  - script: dotnet pack ${{ parameters.packageSolutionFile }} --no-build --configuration $(buildConfiguration) --version-suffix $(VersionSuffixPackage) --output $(Build.artifactStagingDirectory)/packages
     displayName: 'dotnet pack $(buildConfiguration) with version suffix'
     condition: and(succeeded(), eq(variables.UseVersionSuffix, 'true'))
 
-  - script: dotnet pack --no-build --configuration $(buildConfiguration) --output $(Build.artifactStagingDirectory)/packages
+  - script: dotnet pack ${{ parameters.packageSolutionFile }} --no-build --configuration $(buildConfiguration) --output $(Build.artifactStagingDirectory)/packages
     displayName: 'dotnet pack $(buildConfiguration)'
     condition: and(succeeded(), eq(variables.UseVersionSuffix, 'false'))
 

--- a/strongNameSigning.yml
+++ b/strongNameSigning.yml
@@ -32,6 +32,7 @@ steps:
       inputs:
         secureFile: '${{ parameters.signingToolName }}'
     - powershell: |
+          Write-Host "Get-ChildItem -Path ${{ parameters.filesForSigning }} -Exclude ${{ parameters.filesToExcludeForSigning }}"
           $files   =  Get-ChildItem -Path ${{ parameters.filesForSigning }} -Exclude ${{ parameters.filesToExcludeForSigning }}
 
           Write-Verbose "Last exitcode before signing: $lastexitcode"


### PR DESCRIPTION
Enable long paths for git to support submodules, improve flexibility with string parameters for solution files, and update test command arguments in the build configuration. Additionally, add debug output for file listing in the signing process.