### PR TITLE
Add task to push symbol packages to NuGet server

### DIFF
--- a/push-nuget-package.yml
+++ b/push-nuget-package.yml
@@ -29,3 +29,13 @@ steps:
       --source ${{ parameters.source }}
       --api-key ${{ parameters.apiKey }}
       --skip-duplicate
+- task: DotNetCoreCLI@2
+  displayName: Push symbol packages to NuGet server
+  inputs:
+    command: custom
+    custom: nuget
+    arguments: >
+      push $(Build.ArtifactStagingDirectory)$(PATH_SEPARATOR)${{ parameters.artifact }}$(PATH_SEPARATOR)*.snupkg
+      --source ${{ parameters.source }}
+      --api-key ${{ parameters.apiKey }}
+      --skip-duplicate


### PR DESCRIPTION
Will allow to step into the decompiled package code in the editor with properly formatted code much closed to the source package