### PR TITLE
Add version-prefixed image tagging support

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -229,8 +229,9 @@ jobs:
           $version = $versionPrefix
         }
         
-        #Setting output variable $Version (used for VSTS) 
-        Write-Host "##vso[task.setvariable variable=Version;isOutput=true]$version" 
+        #Setting output variable $Version (used for VSTS)
+        Write-Host "##vso[task.setvariable variable=Version;isOutput=true]$version"
+        Write-Host "##vso[task.setvariable variable=VersionPrefix;isOutput=true]$versionPrefix"
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet test UnitTests with filter'

--- a/buildAndPushDockerImage.yml
+++ b/buildAndPushDockerImage.yml
@@ -42,6 +42,8 @@ jobs:
 - job: createDockerImage
   displayName: Docker image
   dependsOn: ${{ parameters.dependsOn }}
+  variables:
+    imageTagPrefix: ${{ parameters.imageTagPrefix }}
   steps:
   - ${{ if ne(parameters.publishedCodeArtifactName, '') }}:
     - task: DownloadPipelineArtifact@2
@@ -82,7 +84,7 @@ jobs:
       if [ "${{ parameters.addLatestTag }}" = "True" ]; then 
         docker buildx build --platform linux/amd64,linux/arm64 \
           --build-arg=PUBLISHED_CODE=azuredevops \
-          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:${{ parameters.imageTagPrefix }}$(Build.BuildNumber) \
+          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(imageTagPrefix)$(Build.BuildNumber) \
           --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:latest \
           --push \
           --file ${{ parameters.dockerFile }} \
@@ -90,7 +92,7 @@ jobs:
       else
         docker buildx build --platform linux/amd64,linux/arm64 \
           --build-arg=PUBLISHED_CODE=azuredevops \
-          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:${{ parameters.imageTagPrefix }}$(Build.BuildNumber) \
+          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(imageTagPrefix)$(Build.BuildNumber) \
           --push \
           --file ${{ parameters.dockerFile }} \
           $workingDir

--- a/buildAndPushDockerImage.yml
+++ b/buildAndPushDockerImage.yml
@@ -29,6 +29,10 @@ parameters:
 - name: imageRepositoryName
   type: string
   displayName: 'The name of the Docker Image Repository'
+- name: imageTagPrefix
+  type: string
+  default: ''
+  displayName: 'Prefix for the image tag (e.g. "6.7.2-"), prepended to Build.BuildNumber'
 - name: dockerhubRegistryConnection
   type: string
   default: ''
@@ -78,7 +82,7 @@ jobs:
       if [ "${{ parameters.addLatestTag }}" = "True" ]; then 
         docker buildx build --platform linux/amd64,linux/arm64 \
           --build-arg=PUBLISHED_CODE=azuredevops \
-          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(Build.BuildNumber) \
+          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:${{ parameters.imageTagPrefix }}$(Build.BuildNumber) \
           --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:latest \
           --push \
           --file ${{ parameters.dockerFile }} \
@@ -86,7 +90,7 @@ jobs:
       else
         docker buildx build --platform linux/amd64,linux/arm64 \
           --build-arg=PUBLISHED_CODE=azuredevops \
-          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(Build.BuildNumber) \
+          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:${{ parameters.imageTagPrefix }}$(Build.BuildNumber) \
           --push \
           --file ${{ parameters.dockerFile }} \
           $workingDir


### PR DESCRIPTION
## Summary
- Add `imageTagPrefix` parameter to `buildAndPushDockerImage.yml` so callers can prepend a version to the build image tag (e.g. `6.7.2-build-20260416.1` instead of `build-20260416.1`)
- Add `VersionPrefix` output variable to `build.yml` — the clean base version without build suffix, for use as image tag prefix
- The parameter defaults to empty string, so existing callers are unaffected (backwards compatible)

Part of DEVOPS-724: ACR image cleanup — enables version-based cleanup of old build images.

## Implementation notes
- The `imageTagPrefix` parameter is resolved via a job-level `variables:` block (not directly in the bash script), because callers pass `$[ ]` runtime expressions that need proper resolution context
- Callers should use `$[ format('{0}-', expr) ]` to include the dash separator inside the runtime expression

## Test plan
- [x] Firely.Auth build tested — produces `4.6.0-build-YYYYMMDD.N` tags
- [x] Firely Server build tested — produces correct version-prefixed tags
- [x] Backwards compatible — callers that don't pass `imageTagPrefix` get unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)