### PR TITLE
DEVOPS-724: Move version prefix into Build.BuildNumber for deploy pipeline compatibility

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -233,6 +233,10 @@ jobs:
         Write-Host "##vso[task.setvariable variable=Version;isOutput=true]$version"
         Write-Host "##vso[task.setvariable variable=VersionPrefix;isOutput=true]$versionPrefix"
 
+        # Update the build number to include the version prefix, so that downstream
+        # pipelines (deploy) can use resources.pipeline.build.runName as the image tag.
+        Write-Host "##vso[build.updatebuildnumber]${versionPrefix}-$(Build.BuildNumber)"
+
   - task: DotNetCoreCLI@2
     displayName: 'dotnet test UnitTests with filter'
     condition: and(succeeded(), ne('${{ parameters.testFilter }}', ''))

--- a/buildAndPushDockerImage.yml
+++ b/buildAndPushDockerImage.yml
@@ -29,10 +29,6 @@ parameters:
 - name: imageRepositoryName
   type: string
   displayName: 'The name of the Docker Image Repository'
-- name: imageTagPrefix
-  type: string
-  default: ''
-  displayName: 'Prefix for the image tag (e.g. "6.7.2-"), prepended to Build.BuildNumber'
 - name: dockerhubRegistryConnection
   type: string
   default: ''
@@ -42,8 +38,6 @@ jobs:
 - job: createDockerImage
   displayName: Docker image
   dependsOn: ${{ parameters.dependsOn }}
-  variables:
-    imageTagPrefix: ${{ parameters.imageTagPrefix }}
   steps:
   - ${{ if ne(parameters.publishedCodeArtifactName, '') }}:
     - task: DownloadPipelineArtifact@2
@@ -84,7 +78,7 @@ jobs:
       if [ "${{ parameters.addLatestTag }}" = "True" ]; then 
         docker buildx build --platform linux/amd64,linux/arm64 \
           --build-arg=PUBLISHED_CODE=azuredevops \
-          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(imageTagPrefix)$(Build.BuildNumber) \
+          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(Build.BuildNumber) \
           --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:latest \
           --push \
           --file ${{ parameters.dockerFile }} \
@@ -92,7 +86,7 @@ jobs:
       else
         docker buildx build --platform linux/amd64,linux/arm64 \
           --build-arg=PUBLISHED_CODE=azuredevops \
-          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(imageTagPrefix)$(Build.BuildNumber) \
+          --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(Build.BuildNumber) \
           --push \
           --file ${{ parameters.dockerFile }} \
           $workingDir


### PR DESCRIPTION
## Summary

Deploy pipelines use `$(resources.pipeline.build.runName)` as the Docker image tag to pull from ACR. The `runName` equals `Build.BuildNumber`, but Docker images were tagged with `<version>-Build.BuildNumber` (via the `imageTagPrefix` parameter) — causing a mismatch that broke deploys after the DEVOPS-724 version-prefix change.

**Fix:** Instead of prepending the version prefix at tag-time, we now update `Build.BuildNumber` itself to include the prefix via `##vso[build.updatebuildnumber]`. This means `runName`, `Build.BuildNumber`, and the Docker tag are all identical (`<version>-build-YYYYMMDD.N`).

## Changes

- **`build.yml`** — Adds `##vso[build.updatebuildnumber]${versionPrefix}-$(Build.BuildNumber)` after the `OutputVersion` step (only fires when `propsFile` is specified, so repos that don't use version detection are unaffected)
- **`buildAndPushDockerImage.yml`** — Removes the `imageTagPrefix` parameter entirely; the Docker tag now uses `$(Build.BuildNumber)` directly (which already contains the version prefix after `updatebuildnumber` fires)

## Merge order

This PR must be merged and the `v1` tag updated **before** the corresponding Vonk and Firely.Auth PRs can be merged, since those repos reference this template via the `v1` tag.

## Test plan

- [x] FA build `4.6.0-build-20260421.2` — build number correctly version-prefixed, Docker tag matches, deploy pipeline succeeded
- [x] FS build `6.8.0-build-20260421.14` — same result (FS uses its own `updatebuildnumber` step added directly in Vonk repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)