### PR TITLE
Never skip builds for version tag refs

### DIFF
--- a/check-skip-stage.yml
+++ b/check-skip-stage.yml
@@ -30,6 +30,15 @@ parameters:
   default: []
   # List of PowerShell-style regex patterns. If all changed files match
   # at least one pattern, the stage's `skip` output variable is set to 'true'.
+- name: neverSkipRefPatterns
+  type: object
+  default:
+    - '^refs/tags/v.*$'
+  # List of regex patterns matched against Build.SourceBranch. If the
+  # current build's ref matches any pattern, the skip output variable
+  # is forced to 'false' regardless of which files changed. Defaults to
+  # version tags (refs/tags/v*) so release builds are never skipped.
+  # Pass an empty list to disable.
 - name: vmImage
   type: string
   default: 'ubuntu-latest'
@@ -47,11 +56,22 @@ stages:
       fetchDepth: 0
     - powershell: |
         $patterns = '${{ convertToJson(parameters.ignorePatterns) }}' | ConvertFrom-Json
+        $neverSkipRefPatterns = '${{ convertToJson(parameters.neverSkipRefPatterns) }}' | ConvertFrom-Json
 
         if ($patterns.Count -eq 0) {
           Write-Host "No ignorePatterns supplied; skip is always 'false'."
           Write-Host "##vso[task.setvariable variable=skip;isOutput=true]false"
           exit 0
+        }
+
+        if ($neverSkipRefPatterns.Count -gt 0 -and $env:BUILD_SOURCEBRANCH) {
+          foreach ($refPattern in $neverSkipRefPatterns) {
+            if ($env:BUILD_SOURCEBRANCH -match $refPattern) {
+              Write-Host "Ref '$env:BUILD_SOURCEBRANCH' matches neverSkipRefPattern '$refPattern'; build will run."
+              Write-Host "##vso[task.setvariable variable=skip;isOutput=true]false"
+              exit 0
+            }
+          }
         }
 
         Write-Host "##[group]Ignore patterns"


### PR DESCRIPTION
## Summary

Tag builds (e.g. `v6.2.0`) currently get skipped when the tagged commit only touches files matching `ignorePatterns` (typically `release-notes.md`). For release tags this is exactly the case where we *want* the pipeline to run.

Adds a new `neverSkipRefPatterns` parameter (list of regex patterns matched against `Build.SourceBranch`). If any pattern matches, the skip check short-circuits to `false` regardless of changed files.

**Default**: `[''^refs/tags/v.*$'']` — version tag builds always run. Pass `[]` to disable.

## Test plan

- [ ] Tag-build path: cut a `vX.Y.Z` tag whose tagged commit only changes `.md` files; pipeline runs end-to-end.
- [ ] Branch-build path (unchanged): docs-only branch commit still skips.
- [ ] Override path: consumer with `neverSkipRefPatterns: []` still skips on a `v*` tag with only docs changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)