### PR TITLE
Added a parameter for kubescan exception file

### DIFF
--- a/scanKubernetesCluster.yml
+++ b/scanKubernetesCluster.yml
@@ -30,6 +30,8 @@ jobs:
   steps:
   - ${{ if ne(parameters.exceptionsFile, '') }}:
     - checkout: self
+  - ${{ else }}:
+    - checkout: none
 
   - script: |
       echo "Validating that we are running on a system with apt..."
@@ -60,12 +62,18 @@ jobs:
     displayName: 'Install Kubescape using apt'
 
   - script: |
-      EXCEPTIONS_ARG=""
-      if [ -n "${{ parameters.exceptionsFile }}" ]; then
-        EXCEPTIONS_ARG="--exceptions ${{ parameters.exceptionsFile }}"
+      set -euo pipefail
+      EXCEPTIONS_FILE="${{ parameters.exceptionsFile }}"
+      SCAN_ARGS=(scan --format "${{ parameters.outputFormat }}" --output "${{ parameters.outputFile }}")
+      if [ -n "$EXCEPTIONS_FILE" ]; then
+        if [ ! -f "$EXCEPTIONS_FILE" ]; then
+          echo "Exceptions file not found: $EXCEPTIONS_FILE" >&2
+          exit 1
+        fi
+        SCAN_ARGS+=(--exceptions "$EXCEPTIONS_FILE")
       fi
-      echo "Running Kubescape scan with arguments: --format ${{ parameters.outputFormat }} --output ${{ parameters.outputFile }} $EXCEPTIONS_ARG"
-      kubescape scan --format ${{ parameters.outputFormat }} --output ${{ parameters.outputFile }} $EXCEPTIONS_ARG
+      echo "Running Kubescape ${SCAN_ARGS[*]}"
+      kubescape "${SCAN_ARGS[@]}"
     displayName: 'Run Kubescape scan'
 
   - publish: ${{ parameters.outputFile }}

--- a/scanKubernetesCluster.yml
+++ b/scanKubernetesCluster.yml
@@ -17,6 +17,10 @@ parameters:
     type: string
     default: 'kubescape-results'
     displayName: 'Name of the artifact to publish'
+  - name: exceptionsFile
+    type: string
+    default: ''
+    displayName: 'Path to a Kubescape exceptions JSON file (optional)'
 
 jobs:
 - job: scan
@@ -24,6 +28,9 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
   steps:
+  - ${{ if ne(parameters.exceptionsFile, '') }}:
+    - checkout: self
+
   - script: |
       echo "Validating that we are running on a system with apt..."
       if [ "$(uname -s)" != "Linux" ] || ! command -v apt >/dev/null 2>&1; then
@@ -53,8 +60,12 @@ jobs:
     displayName: 'Install Kubescape using apt'
 
   - script: |
-      echo "Running Kubescape scan with arguments: --format ${{ parameters.outputFormat }} --output ${{ parameters.outputFile }}"
-      kubescape scan --format ${{ parameters.outputFormat }} --output ${{ parameters.outputFile }}
+      EXCEPTIONS_ARG=""
+      if [ -n "${{ parameters.exceptionsFile }}" ]; then
+        EXCEPTIONS_ARG="--exceptions ${{ parameters.exceptionsFile }}"
+      fi
+      echo "Running Kubescape scan with arguments: --format ${{ parameters.outputFormat }} --output ${{ parameters.outputFile }} $EXCEPTIONS_ARG"
+      kubescape scan --format ${{ parameters.outputFormat }} --output ${{ parameters.outputFile }} $EXCEPTIONS_ARG
     displayName: 'Run Kubescape scan'
 
   - publish: ${{ parameters.outputFile }}


### PR DESCRIPTION
This pull request updates the `scanKubernetesCluster.yml` pipeline to support using a Kubescape exceptions file during cluster scans. The main changes add a new parameter for specifying the exceptions file and update the scan step to include it if provided.

Parameter and scan step enhancements:

* Added a new `exceptionsFile` parameter to the pipeline, allowing users to optionally specify the path to a Kubescape exceptions JSON file.
* Updated the scan step to conditionally include the `--exceptions` flag in the `kubescape scan` command if the `exceptionsFile` parameter is set.