### PR TITLE
DEVOPS-771: weekly Docker image vulnerability scan — template additions and fixes

### DIFF
--- a/convertTrivyIgnoreToVex.yml
+++ b/convertTrivyIgnoreToVex.yml
@@ -18,10 +18,15 @@ parameters:
   type: string
   default: 'Convert trivyIgnore to OpenVEX'
   displayName: 'Display name for this step'
+- name: condition
+  type: string
+  default: 'succeeded()'
+  displayName: 'Condition expression for this step'
 
 steps:
 - task: PowerShell@2
   displayName: ${{ parameters.displayName }}
+  condition: ${{ parameters.condition }}
   inputs:
     targetType: inline
     script: |

--- a/convertTrivyIgnoreToVex.yml
+++ b/convertTrivyIgnoreToVex.yml
@@ -1,0 +1,108 @@
+# Repo: FirelyTeam/azure-pipeline-templates
+# File: convertTrivyIgnoreToVex.yml
+# Description: Convert a .trivyignore file to an OpenVEX JSON file for use with Docker Scout.
+#              Creates an empty OpenVEX document if the trivyignore file is not found.
+
+parameters:
+- name: trivyIgnoreFile
+  type: string
+  default: ''
+  displayName: 'Path to .trivyignore file; creates empty OpenVEX if not found'
+- name: outputFile
+  type: string
+  displayName: 'Output path for the generated OpenVEX JSON file (e.g. vex.json)'
+- name: productPurl
+  type: string
+  displayName: 'Package URL identifying the product (e.g. pkg:docker/firely/server@5.3.0)'
+- name: displayName
+  type: string
+  default: 'Convert trivyIgnore to OpenVEX'
+  displayName: 'Display name for this step'
+
+steps:
+- task: PowerShell@2
+  displayName: ${{ parameters.displayName }}
+  inputs:
+    targetType: inline
+    script: |
+      $TrivyIgnoreFile = "${{ parameters.trivyIgnoreFile }}"
+      $OutputFile      = "${{ parameters.outputFile }}"
+      $Author          = "devops@fire.ly"
+      $ProductPurl     = "${{ parameters.productPurl }}"
+
+      Write-Host "Converting trivyignore -> OpenVEX"
+      Write-Host "Input : $TrivyIgnoreFile"
+      Write-Host "Output: $OutputFile"
+
+      $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:sszzz")
+      $vexId     = "https://openvex.dev/docs/public/vex-" + ([guid]::NewGuid().ToString().ToLower())
+
+      if (-not (Test-Path $TrivyIgnoreFile)) {
+        Write-Host "No trivyignore file found at '$TrivyIgnoreFile'. Creating empty OpenVEX."
+        $document = @{
+          "@context" = "https://openvex.dev/ns/v0.2.0"
+          "@id"      = $vexId
+          author     = $Author
+          timestamp  = $timestamp
+          version    = 1
+          statements = @()
+        }
+        $document | ConvertTo-Json -Depth 10 | Out-File -Encoding utf8 -FilePath $OutputFile
+        Write-Host "Created empty OpenVEX file: $OutputFile"
+      }
+      else {
+        $statements = @()
+        $today = Get-Date
+
+        Get-Content $TrivyIgnoreFile | ForEach-Object {
+          $line = $_.Trim()
+          if ($line -eq "" -or $line.StartsWith("#")) { return }
+
+          $CVE    = $line.Split(" ")[0].Trim()
+          $Expiry = $null
+          if ($line -match "exp:(\d{4}-\d{2}-\d{2})") { $Expiry = $Matches[1] }
+
+          if ($Expiry) {
+            $expiryDate = Get-Date $Expiry
+            if ($expiryDate -le $today) {
+              $Status        = "affected"
+              $Justification = "no_known_fix"
+              $Impact        = "Ignore period expired on $Expiry"
+            }
+            else {
+              $Status        = "not_affected"
+              $Justification = "no_known_fix"
+              $Impact        = "Ignored via .trivyignore migration (expires on $Expiry)"
+            }
+          }
+          else {
+            $Status        = "not_affected"
+            $Justification = "no_known_fix"
+            $Impact        = "Ignored via .trivyignore migration"
+          }
+
+          $statements += @{
+            vulnerability    = @{ name = $CVE }
+            timestamp        = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:sszzz")
+            products         = @(@{ "@id" = $ProductPurl })
+            status           = $Status
+            justification    = $Justification
+            impact_statement = $Impact
+          }
+        }
+
+        $document = @{
+          "@context" = "https://openvex.dev/ns/v0.2.0"
+          "@id"      = $vexId
+          author     = $Author
+          timestamp  = $timestamp
+          version    = 1
+          statements = $statements
+        }
+        $document | ConvertTo-Json -Depth 10 | Out-File -Encoding utf8 -FilePath $OutputFile
+
+        Write-Host "OpenVEX file created: $OutputFile"
+        Write-Host "----------------------------------------"
+        Get-Content $OutputFile | Write-Host
+        Write-Host "----------------------------------------"
+      }

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -67,104 +67,13 @@ jobs:
       command: login
       containerRegistry: ${{ parameters.dockerhubRegistryConnection }}
       
-  - task: PowerShell@2
-    displayName: "Convert trivyignore.txt to OpenVEX file"
+  - template: convertTrivyIgnoreToVex.yml
     condition: and(succeeded(), eq(variables['run_docker_scout'], 'true'))
-    inputs:
-      targetType: inline
-      script: |
-        $TrivyIgnoreFile = "${{ parameters.trivyIgnoreFile }}"
-        $OutputFile      = "vex.json"
-        $Author          = "devops@fire.ly"
-        $ProductPurl     = "$(docker_image_package_url)"
-
-        Write-Host "Converting trivyignore → OpenVEX"
-        Write-Host "Input: $TrivyIgnoreFile"
-        Write-Host "Output: $OutputFile"
-
-        # RFC3339 timestamp
-        $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:sszzz")
-        $vexId = "https://openvex.dev/docs/public/vex-" + ([guid]::NewGuid().ToString().ToLower())
-
-        if (-not (Test-Path $TrivyIgnoreFile)) {
-          Write-Host "No trivy ignore file found at '$TrivyIgnoreFile'. Creating empty OpenVEX ($OutputFile) with no statements."
-          $document = @{
-            "@context" = "https://openvex.dev/ns/v0.2.0"
-            "@id" = $vexId
-            author = $Author
-            timestamp = $timestamp
-            version = 1
-            statements = @()
-          }
-          $document | ConvertTo-Json -Depth 10 | Out-File -Encoding utf8 -FilePath $OutputFile
-          Write-Host "Created empty OpenVEX file: $OutputFile"
-        }
-        else {
-          $statements = @()
-          $today = Get-Date
-
-          Get-Content $TrivyIgnoreFile | ForEach-Object {
-            $line = $_.Trim()
-            if ($line -eq "" -or $line.StartsWith("#")) { return }
-
-            $CVE = $line.Split(" ")[0].Trim()
-
-            $Expiry = $null
-            if ($line -match "exp:(\d{4}-\d{2}-\d{2})") {
-              $Expiry = $Matches[1]
-            }
-
-            if ($Expiry) {
-              $expiryDate = Get-Date $Expiry
-
-              if ($expiryDate -le $today) {
-                $Status = "affected"
-                $Justification = "no_known_fix"
-                $Impact = "Ignore period expired on $Expiry"
-              }
-              else {
-                $Status = "not_affected"
-                $Justification = "no_known_fix"
-                $Impact = "Ignored via .trivyignore migration (expires on $Expiry)"
-              }
-            }
-            else {
-              $Status = "not_affected"
-              $Justification = "no_known_fix"
-              $Impact = "Ignored via .trivyignore migration"
-            }
-
-            $stmtTs = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:sszzz")
-
-            $stmt = @{
-              vulnerability = @{ name = $CVE }
-              timestamp = $stmtTs
-              products = @(@{ "@id" = $ProductPurl })
-              status = $Status
-              justification = $Justification
-              impact_statement = $Impact
-            }
-
-            $statements += $stmt
-          }
-
-          $document = @{
-            "@context" = "https://openvex.dev/ns/v0.2.0"
-            "@id" = $vexId
-            author = $Author
-            timestamp = $timestamp
-            version = 1
-            statements = $statements
-          }
-
-          $document | ConvertTo-Json -Depth 10 | Out-File -Encoding utf8 -FilePath $OutputFile
-
-          Write-Host "OpenVEX file created: $OutputFile"
-          Write-Host "Printing vex.json:"
-          Write-Host "----------------------------------------"
-          Get-Content $OutputFile | Write-Host
-          Write-Host "----------------------------------------"
-        }  
+    parameters:
+      trivyIgnoreFile: ${{ parameters.trivyIgnoreFile }}
+      outputFile: vex.json
+      productPurl: $(docker_image_package_url)
+      displayName: "Convert trivyignore.txt to OpenVEX file"
 
   - task: CmdLine@2
     displayName: Run docker scout on image

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -68,12 +68,12 @@ jobs:
       containerRegistry: ${{ parameters.dockerhubRegistryConnection }}
       
   - template: convertTrivyIgnoreToVex.yml
-    condition: and(succeeded(), eq(variables['run_docker_scout'], 'true'))
     parameters:
       trivyIgnoreFile: ${{ parameters.trivyIgnoreFile }}
       outputFile: vex.json
       productPurl: $(docker_image_package_url)
       displayName: "Convert trivyignore.txt to OpenVEX file"
+      condition: "and(succeeded(), eq(variables['run_docker_scout'], 'true'))"
 
   - task: CmdLine@2
     displayName: Run docker scout on image

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -85,20 +85,24 @@ jobs:
         install_dir="$DOCKER_CONFIG/cli-plugins"
         echo "Installing Docker Scout CLI to ${install_dir}"
         curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s -- -b ${install_dir}
+        FAILED=0
         echo "Get a CVE report for the base image"
-        docker scout cves --vex-location vex.json --only-base ${{ variables['docker_image_full_name'] }} --exit-code --only-severity critical,high,medium,low 
+        docker scout cves --vex-location vex.json --only-base ${{ variables['docker_image_full_name'] }} --exit-code --only-severity critical,high,medium,low
         if [ $? -ne 0 ]; then
           echo "Vulnerabilities found in packages installed in the base image"
+          FAILED=1
         else
           echo "No vulnerabilities found in packages installed in the base image"
         fi
-        echo "Get a CVE report for the built image (without considering CVE from base image) "
-        docker scout cves --vex-location vex.json --ignore-base ${{ variables['docker_image_full_name'] }} --exit-code --only-severity critical,high,medium,low 
+        echo "Get a CVE report for the built image (without considering CVE from base image)"
+        docker scout cves --vex-location vex.json --ignore-base ${{ variables['docker_image_full_name'] }} --exit-code --only-severity critical,high,medium,low
         if [ $? -ne 0 ]; then
           echo "Vulnerabilities found in packages installed in the image"
+          FAILED=1
         else
           echo "No vulnerabilities found in packages installed in the image"
         fi
+        exit $FAILED
 
   - template: ./scanWithRetryTask.yml
     parameters:

--- a/scanReleasedImage.yml
+++ b/scanReleasedImage.yml
@@ -1,0 +1,204 @@
+# Repo: FirelyTeam/azure-pipeline-templates
+# File: scanReleasedImage.yml
+# Description: Pull a released Docker image and scan it with Docker Scout and Trivy.
+# Prerequisites: Docker Hub must already be logged in and Docker Scout CLI installed.
+
+parameters:
+- name: imageName
+  type: string
+  displayName: 'Docker image repository name (e.g. firely/server)'
+- name: imageTag
+  type: string
+  displayName: 'Docker image tag (e.g. 5.3.0 or a runtime variable like $(FS_CURRENT))'
+- name: scanId
+  type: string
+  displayName: 'Short unique ID used for temp file names (e.g. fs-current, fa, fsi)'
+- name: trivyIgnoreFile
+  type: string
+  default: ''
+  displayName: 'Path to .trivyignore file; creates empty OpenVEX if not found'
+- name: trivyCacheAzureSubscription
+  type: string
+  default: ''
+  displayName: 'Azure subscription used to retrieve the Trivy DB cache'
+- name: trivyCacheStorageAccount
+  type: string
+  default: ''
+  displayName: 'Storage account name where the Trivy DB cache is stored'
+- name: dockerhubRegistryConnection
+  type: string
+  default: ''
+  displayName: 'Docker Hub service connection (required for Docker Scout)'
+- name: vulnFoundVariableName
+  type: string
+  default: ''
+  displayName: 'Pipeline variable to set to "true" when vulnerabilities are found'
+- name: scoutSummaryVariableName
+  type: string
+  default: ''
+  displayName: 'Pipeline variable to store Scout CVE severity summary (e.g. "2 high, 1 medium")'
+- name: scoutCvesVariableName
+  type: string
+  default: ''
+  displayName: 'Pipeline variable to store Scout CVE list (semicolon-separated CVE|lib|ver|sev)'
+- name: trivySummaryVariableName
+  type: string
+  default: ''
+  displayName: 'Pipeline variable to store Trivy CVE severity summary'
+- name: trivyCvesVariableName
+  type: string
+  default: ''
+  displayName: 'Pipeline variable to store Trivy CVE list (semicolon-separated CVE|lib|ver|sev)'
+
+steps:
+- script: docker pull ${{ parameters.imageName }}:${{ parameters.imageTag }}
+  displayName: "Pull ${{ parameters.imageName }}:${{ parameters.imageTag }}"
+
+- task: PowerShell@2
+  displayName: "Convert trivyIgnore to OpenVEX for ${{ parameters.imageName }}:${{ parameters.imageTag }}"
+  inputs:
+    targetType: inline
+    script: |
+      $TrivyIgnoreFile = "${{ parameters.trivyIgnoreFile }}"
+      $OutputFile      = "vex-${{ parameters.scanId }}.json"
+      $Author          = "devops@fire.ly"
+      $ProductPurl     = "pkg:docker/${{ parameters.imageName }}@${{ parameters.imageTag }}"
+
+      Write-Host "Converting trivyignore -> OpenVEX"
+      Write-Host "Input : $TrivyIgnoreFile"
+      Write-Host "Output: $OutputFile"
+
+      $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:sszzz")
+      $vexId     = "https://openvex.dev/docs/public/vex-" + ([guid]::NewGuid().ToString().ToLower())
+
+      if (-not (Test-Path $TrivyIgnoreFile)) {
+        Write-Host "No trivyignore file found at '$TrivyIgnoreFile'. Creating empty OpenVEX."
+        $document = @{
+          "@context" = "https://openvex.dev/ns/v0.2.0"
+          "@id"      = $vexId
+          author     = $Author
+          timestamp  = $timestamp
+          version    = 1
+          statements = @()
+        }
+        $document | ConvertTo-Json -Depth 10 | Out-File -Encoding utf8 -FilePath $OutputFile
+      }
+      else {
+        $statements = @()
+        $today = Get-Date
+
+        Get-Content $TrivyIgnoreFile | ForEach-Object {
+          $line = $_.Trim()
+          if ($line -eq "" -or $line.StartsWith("#")) { return }
+
+          $CVE = $line.Split(" ")[0].Trim()
+
+          $Expiry = $null
+          if ($line -match "exp:(\d{4}-\d{2}-\d{2})") { $Expiry = $Matches[1] }
+
+          if ($Expiry) {
+            $expiryDate = Get-Date $Expiry
+            if ($expiryDate -le $today) {
+              $Status        = "affected"
+              $Justification = "no_known_fix"
+              $Impact        = "Ignore period expired on $Expiry"
+            }
+            else {
+              $Status        = "not_affected"
+              $Justification = "no_known_fix"
+              $Impact        = "Ignored via .trivyignore migration (expires on $Expiry)"
+            }
+          }
+          else {
+            $Status        = "not_affected"
+            $Justification = "no_known_fix"
+            $Impact        = "Ignored via .trivyignore migration"
+          }
+
+          $statements += @{
+            vulnerability    = @{ name = $CVE }
+            timestamp        = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:sszzz")
+            products         = @(@{ "@id" = $ProductPurl })
+            status           = $Status
+            justification    = $Justification
+            impact_statement = $Impact
+          }
+        }
+
+        $document = @{
+          "@context" = "https://openvex.dev/ns/v0.2.0"
+          "@id"      = $vexId
+          author     = $Author
+          timestamp  = $timestamp
+          version    = 1
+          statements = $statements
+        }
+        $document | ConvertTo-Json -Depth 10 | Out-File -Encoding utf8 -FilePath $OutputFile
+        Write-Host "OpenVEX file created: $OutputFile"
+      }
+
+- task: CmdLine@2
+  displayName: "Docker Scout — ${{ parameters.imageName }}:${{ parameters.imageTag }}"
+  continueOnError: true
+  inputs:
+    script: |
+      FAILED=0
+      docker scout cves --vex-location vex-${{ parameters.scanId }}.json --only-base ${{ parameters.imageName }}:${{ parameters.imageTag }} --exit-code --only-severity critical,high,medium,low 2>&1 | tee /tmp/scout-${{ parameters.scanId }}.txt
+      if [ ${PIPESTATUS[0]} -ne 0 ]; then FAILED=1; fi
+      docker scout cves --vex-location vex-${{ parameters.scanId }}.json --ignore-base ${{ parameters.imageName }}:${{ parameters.imageTag }} --exit-code --only-severity critical,high,medium,low 2>&1 | tee -a /tmp/scout-${{ parameters.scanId }}.txt
+      if [ ${PIPESTATUS[0]} -ne 0 ]; then FAILED=1; fi
+      SUMMARY=$(python3 -c "
+      import re
+      counts = {}
+      for line in open('/tmp/scout-${{ parameters.scanId }}.txt'):
+          m = re.search(r'\b(CRITICAL|HIGH|MEDIUM|LOW)\s+(\d+)\s*$', line)
+          if m:
+              k = m.group(1).lower()
+              counts[k] = counts.get(k, 0) + int(m.group(2))
+      order = ['critical','high','medium','low']
+      parts = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
+      print(', '.join(parts) if parts else '')
+      ")
+      echo "Scout CVE summary (${{ parameters.imageName }}:${{ parameters.imageTag }}): ${SUMMARY:-none}"
+      SCOUT_SUMMARY_VAR="${{ parameters.scoutSummaryVariableName }}"
+      if [ -n "$SCOUT_SUMMARY_VAR" ]; then
+        echo "##vso[task.setvariable variable=$SCOUT_SUMMARY_VAR]$SUMMARY"
+      fi
+      CVES=$(python3 -c "
+      import re
+      results = []
+      cur_lib = cur_ver = None
+      for line in open('/tmp/scout-${{ parameters.scanId }}.txt'):
+          m = re.match(r'\s+\d+C\s+\d+H\s+\d+M\s+\d+L\s+(\S+)\s+(\S+)\s*$', line)
+          if m:
+              cur_lib, cur_ver = m.group(1), m.group(2)
+              continue
+          m = re.search(r'✗\s+(CRITICAL|HIGH|MEDIUM|LOW)\s+(CVE-\S+)', line)
+          if m and cur_lib:
+              results.append(m.group(2) + '|' + cur_lib + '|' + cur_ver + '|' + m.group(1))
+      seen = set()
+      deduped = [r for r in results if not (r.split('|')[0] in seen or seen.add(r.split('|')[0]))]
+      print(';'.join(deduped))
+      ")
+      SCOUT_CVES_VAR="${{ parameters.scoutCvesVariableName }}"
+      if [ -n "$SCOUT_CVES_VAR" ]; then
+        echo "##vso[task.setvariable variable=$SCOUT_CVES_VAR]$CVES"
+      fi
+      VULN_VAR="${{ parameters.vulnFoundVariableName }}"
+      if [ $FAILED -eq 1 ] && [ -n "$VULN_VAR" ]; then
+        echo "##vso[task.setvariable variable=$VULN_VAR]true"
+      fi
+      exit $FAILED
+
+- template: scanWithRetryTask.yml
+  parameters:
+    trivyCacheAzureSubscription: ${{ parameters.trivyCacheAzureSubscription }}
+    trivyCacheStorageAccount: ${{ parameters.trivyCacheStorageAccount }}
+    dockerhubRegistryConnection: ${{ parameters.dockerhubRegistryConnection }}
+    trivyIgnoreFile: ${{ parameters.trivyIgnoreFile }}
+    trivyExtraArguments: image ${{ parameters.imageName }}:${{ parameters.imageTag }}
+    displayName: "Trivy — ${{ parameters.imageName }}:${{ parameters.imageTag }}"
+    continueOnError: true
+    vulnFoundVariableName: ${{ parameters.vulnFoundVariableName }}
+    summaryVariableName: ${{ parameters.trivySummaryVariableName }}
+    cveListVariableName: ${{ parameters.trivyCvesVariableName }}

--- a/scanReleasedImage.yml
+++ b/scanReleasedImage.yml
@@ -54,88 +54,12 @@ steps:
 - script: docker pull ${{ parameters.imageName }}:${{ parameters.imageTag }}
   displayName: "Pull ${{ parameters.imageName }}:${{ parameters.imageTag }}"
 
-- task: PowerShell@2
-  displayName: "Convert trivyIgnore to OpenVEX for ${{ parameters.imageName }}:${{ parameters.imageTag }}"
-  inputs:
-    targetType: inline
-    script: |
-      $TrivyIgnoreFile = "${{ parameters.trivyIgnoreFile }}"
-      $OutputFile      = "vex-${{ parameters.scanId }}.json"
-      $Author          = "devops@fire.ly"
-      $ProductPurl     = "pkg:docker/${{ parameters.imageName }}@${{ parameters.imageTag }}"
-
-      Write-Host "Converting trivyignore -> OpenVEX"
-      Write-Host "Input : $TrivyIgnoreFile"
-      Write-Host "Output: $OutputFile"
-
-      $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:sszzz")
-      $vexId     = "https://openvex.dev/docs/public/vex-" + ([guid]::NewGuid().ToString().ToLower())
-
-      if (-not (Test-Path $TrivyIgnoreFile)) {
-        Write-Host "No trivyignore file found at '$TrivyIgnoreFile'. Creating empty OpenVEX."
-        $document = @{
-          "@context" = "https://openvex.dev/ns/v0.2.0"
-          "@id"      = $vexId
-          author     = $Author
-          timestamp  = $timestamp
-          version    = 1
-          statements = @()
-        }
-        $document | ConvertTo-Json -Depth 10 | Out-File -Encoding utf8 -FilePath $OutputFile
-      }
-      else {
-        $statements = @()
-        $today = Get-Date
-
-        Get-Content $TrivyIgnoreFile | ForEach-Object {
-          $line = $_.Trim()
-          if ($line -eq "" -or $line.StartsWith("#")) { return }
-
-          $CVE = $line.Split(" ")[0].Trim()
-
-          $Expiry = $null
-          if ($line -match "exp:(\d{4}-\d{2}-\d{2})") { $Expiry = $Matches[1] }
-
-          if ($Expiry) {
-            $expiryDate = Get-Date $Expiry
-            if ($expiryDate -le $today) {
-              $Status        = "affected"
-              $Justification = "no_known_fix"
-              $Impact        = "Ignore period expired on $Expiry"
-            }
-            else {
-              $Status        = "not_affected"
-              $Justification = "no_known_fix"
-              $Impact        = "Ignored via .trivyignore migration (expires on $Expiry)"
-            }
-          }
-          else {
-            $Status        = "not_affected"
-            $Justification = "no_known_fix"
-            $Impact        = "Ignored via .trivyignore migration"
-          }
-
-          $statements += @{
-            vulnerability    = @{ name = $CVE }
-            timestamp        = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:sszzz")
-            products         = @(@{ "@id" = $ProductPurl })
-            status           = $Status
-            justification    = $Justification
-            impact_statement = $Impact
-          }
-        }
-
-        $document = @{
-          "@context" = "https://openvex.dev/ns/v0.2.0"
-          "@id"      = $vexId
-          author     = $Author
-          timestamp  = $timestamp
-          version    = 1
-          statements = $statements
-        }
-        $document | ConvertTo-Json -Depth 10 | Out-File -Encoding utf8 -FilePath $OutputFile
-        Write-Host "OpenVEX file created: $OutputFile"
-      }
+- template: convertTrivyIgnoreToVex.yml
+  parameters:
+    trivyIgnoreFile: ${{ parameters.trivyIgnoreFile }}
+    outputFile: vex-${{ parameters.scanId }}.json
+    productPurl: pkg:docker/${{ parameters.imageName }}@${{ parameters.imageTag }}
+    displayName: "Convert trivyIgnore to OpenVEX for ${{ parameters.imageName }}:${{ parameters.imageTag }}"
 
 - task: CmdLine@2
   displayName: "Docker Scout — ${{ parameters.imageName }}:${{ parameters.imageTag }}"

--- a/scanReleasedImage.yml
+++ b/scanReleasedImage.yml
@@ -71,6 +71,8 @@ steps:
       if [ ${PIPESTATUS[0]} -ne 0 ]; then FAILED=1; fi
       docker scout cves --vex-location vex-${{ parameters.scanId }}.json --ignore-base ${{ parameters.imageName }}:${{ parameters.imageTag }} --exit-code --only-severity critical,high,medium,low 2>&1 | tee -a /tmp/scout-${{ parameters.scanId }}.txt
       if [ ${PIPESTATUS[0]} -ne 0 ]; then FAILED=1; fi
+      # Python code is at YAML block base indentation (6 spaces); YAML strips
+      # those spaces before bash runs, so Python receives correctly 0-indented code.
       SUMMARY=$(python3 -c "
       import re
       counts = {}
@@ -88,6 +90,7 @@ steps:
       if [ -n "$SCOUT_SUMMARY_VAR" ]; then
         echo "##vso[task.setvariable variable=$SCOUT_SUMMARY_VAR]$SUMMARY"
       fi
+      # Same YAML indentation stripping applies here.
       CVES=$(python3 -c "
       import re
       results = []

--- a/scanWithRetryTask.yml
+++ b/scanWithRetryTask.yml
@@ -47,6 +47,10 @@ parameters:
   type: string
   default: ''
   displayName: 'Pipeline variable name to set to "true" when vulnerabilities are found (used with continueOnError)'
+- name: summaryVariableName
+  type: string
+  default: ''
+  displayName: 'Pipeline variable name to set to a "N critical, N high, ..." string when vulnerabilities are found'
 
 steps:
 - ${{ if ne(parameters.dockerhubRegistryConnection, '') }}:
@@ -145,6 +149,29 @@ steps:
           if [ -n "$VULN_VAR_NAME" ]; then
             echo "##vso[task.setvariable variable=$VULN_VAR_NAME]true"
           fi
+          SUMMARY_VAR_NAME="${{ parameters.summaryVariableName }}"
+          if [ -n "$SUMMARY_VAR_NAME" ]; then
+            TRIVY_SUMMARY=$(echo "$log_output" | python3 -c "
+import re, sys
+counts = {}
+for line in sys.stdin:
+    m = re.search(r'Total:\s*\d+\s*\(([^)]+)\)', line)
+    if m:
+        for item in m.group(1).split(','):
+            kv = item.strip().split(':')
+            if len(kv) == 2:
+                sev = kv[0].strip().lower()
+                try:
+                    cnt = int(kv[1].strip())
+                    if sev in ('critical','high','medium','low') and cnt > 0:
+                        counts[sev] = counts.get(sev, 0) + cnt
+                except: pass
+order = ['critical','high','medium','low']
+result = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
+print(', '.join(result))
+")
+            echo "##vso[task.setvariable variable=$SUMMARY_VAR_NAME]$TRIVY_SUMMARY"
+          fi
           exit 1
         fi
       fi
@@ -154,6 +181,29 @@ steps:
       VULN_VAR_NAME="${{ parameters.vulnFoundVariableName }}"
       if [ -n "$VULN_VAR_NAME" ]; then
         echo "##vso[task.setvariable variable=$VULN_VAR_NAME]true"
+      fi
+      SUMMARY_VAR_NAME="${{ parameters.summaryVariableName }}"
+      if [ -n "$SUMMARY_VAR_NAME" ]; then
+        TRIVY_SUMMARY=$(echo "$log_output" | python3 -c "
+import re, sys
+counts = {}
+for line in sys.stdin:
+    m = re.search(r'Total:\s*\d+\s*\(([^)]+)\)', line)
+    if m:
+        for item in m.group(1).split(','):
+            kv = item.strip().split(':')
+            if len(kv) == 2:
+                sev = kv[0].strip().lower()
+                try:
+                    cnt = int(kv[1].strip())
+                    if sev in ('critical','high','medium','low') and cnt > 0:
+                        counts[sev] = counts.get(sev, 0) + cnt
+                except: pass
+order = ['critical','high','medium','low']
+result = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
+print(', '.join(result))
+")
+        echo "##vso[task.setvariable variable=$SUMMARY_VAR_NAME]$TRIVY_SUMMARY"
       fi
       exit 1
     fi

--- a/scanWithRetryTask.yml
+++ b/scanWithRetryTask.yml
@@ -156,43 +156,43 @@ steps:
           SUMMARY_VAR_NAME="${{ parameters.summaryVariableName }}"
           if [ -n "$SUMMARY_VAR_NAME" ]; then
             TRIVY_SUMMARY=$(echo "$log_output" | python3 -c "
-import re, sys
-counts = {}
-for line in sys.stdin:
-    m = re.search(r'Total:\s*\d+\s*\(([^)]+)\)', line)
-    if m:
-        for item in m.group(1).split(','):
-            kv = item.strip().split(':')
-            if len(kv) == 2:
-                sev = kv[0].strip().lower()
-                try:
-                    cnt = int(kv[1].strip())
-                    if sev in ('critical','high','medium','low') and cnt > 0:
-                        counts[sev] = counts.get(sev, 0) + cnt
-                except: pass
-order = ['critical','high','medium','low']
-result = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
-print(', '.join(result))
+    import re, sys
+    counts = {}
+    for line in sys.stdin:
+        m = re.search(r'Total:\s*\d+\s*\(([^)]+)\)', line)
+        if m:
+            for item in m.group(1).split(','):
+                kv = item.strip().split(':')
+                if len(kv) == 2:
+                    sev = kv[0].strip().lower()
+                    try:
+                        cnt = int(kv[1].strip())
+                        if sev in ('critical','high','medium','low') and cnt > 0:
+                            counts[sev] = counts.get(sev, 0) + cnt
+                    except: pass
+    order = ['critical','high','medium','low']
+    result = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
+    print(', '.join(result))
 ")
             echo "##vso[task.setvariable variable=$SUMMARY_VAR_NAME]$TRIVY_SUMMARY"
           fi
           CVE_LIST_VAR_NAME="${{ parameters.cveListVariableName }}"
           if [ -n "$CVE_LIST_VAR_NAME" ]; then
             TRIVY_CVES=$(echo "$log_output" | python3 -c "
-import re, sys
-results = []
-seen = set()
-for line in sys.stdin:
-    if '│' not in line:
-        continue
-    parts = [p.strip() for p in line.split('│')]
-    if len(parts) < 6:
-        continue
-    lib, cve, sev, ver = parts[1], parts[2], parts[3], parts[5]
-    if re.match(r'CVE-', cve) and re.match(r'CRITICAL|HIGH|MEDIUM|LOW', sev) and lib and cve not in seen:
-        seen.add(cve)
-        results.append(f'{cve}|{lib}|{ver}|{sev}')
-print(';'.join(results))
+    import re, sys
+    results = []
+    seen = set()
+    for line in sys.stdin:
+        if chr(9474) not in line:
+            continue
+        parts = [p.strip() for p in line.split(chr(9474))]
+        if len(parts) < 6:
+            continue
+        lib, cve, sev, ver = parts[1], parts[2], parts[3], parts[5]
+        if re.match(r'CVE-', cve) and re.match(r'CRITICAL|HIGH|MEDIUM|LOW', sev) and lib and cve not in seen:
+            seen.add(cve)
+            results.append(cve + '|' + lib + '|' + ver + '|' + sev)
+    print(';'.join(results))
 ")
             echo "##vso[task.setvariable variable=$CVE_LIST_VAR_NAME]$TRIVY_CVES"
           fi
@@ -209,43 +209,43 @@ print(';'.join(results))
       SUMMARY_VAR_NAME="${{ parameters.summaryVariableName }}"
       if [ -n "$SUMMARY_VAR_NAME" ]; then
         TRIVY_SUMMARY=$(echo "$log_output" | python3 -c "
-import re, sys
-counts = {}
-for line in sys.stdin:
-    m = re.search(r'Total:\s*\d+\s*\(([^)]+)\)', line)
-    if m:
-        for item in m.group(1).split(','):
-            kv = item.strip().split(':')
-            if len(kv) == 2:
-                sev = kv[0].strip().lower()
-                try:
-                    cnt = int(kv[1].strip())
-                    if sev in ('critical','high','medium','low') and cnt > 0:
-                        counts[sev] = counts.get(sev, 0) + cnt
-                except: pass
-order = ['critical','high','medium','low']
-result = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
-print(', '.join(result))
+    import re, sys
+    counts = {}
+    for line in sys.stdin:
+        m = re.search(r'Total:\s*\d+\s*\(([^)]+)\)', line)
+        if m:
+            for item in m.group(1).split(','):
+                kv = item.strip().split(':')
+                if len(kv) == 2:
+                    sev = kv[0].strip().lower()
+                    try:
+                        cnt = int(kv[1].strip())
+                        if sev in ('critical','high','medium','low') and cnt > 0:
+                            counts[sev] = counts.get(sev, 0) + cnt
+                    except: pass
+    order = ['critical','high','medium','low']
+    result = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
+    print(', '.join(result))
 ")
         echo "##vso[task.setvariable variable=$SUMMARY_VAR_NAME]$TRIVY_SUMMARY"
       fi
       CVE_LIST_VAR_NAME="${{ parameters.cveListVariableName }}"
       if [ -n "$CVE_LIST_VAR_NAME" ]; then
         TRIVY_CVES=$(echo "$log_output" | python3 -c "
-import re, sys
-results = []
-seen = set()
-for line in sys.stdin:
-    if '│' not in line:
-        continue
-    parts = [p.strip() for p in line.split('│')]
-    if len(parts) < 6:
-        continue
-    lib, cve, sev, ver = parts[1], parts[2], parts[3], parts[5]
-    if re.match(r'CVE-', cve) and re.match(r'CRITICAL|HIGH|MEDIUM|LOW', sev) and lib and cve not in seen:
-        seen.add(cve)
-        results.append(f'{cve}|{lib}|{ver}|{sev}')
-print(';'.join(results))
+    import re, sys
+    results = []
+    seen = set()
+    for line in sys.stdin:
+        if chr(9474) not in line:
+            continue
+        parts = [p.strip() for p in line.split(chr(9474))]
+        if len(parts) < 6:
+            continue
+        lib, cve, sev, ver = parts[1], parts[2], parts[3], parts[5]
+        if re.match(r'CVE-', cve) and re.match(r'CRITICAL|HIGH|MEDIUM|LOW', sev) and lib and cve not in seen:
+            seen.add(cve)
+            results.append(cve + '|' + lib + '|' + ver + '|' + sev)
+    print(';'.join(results))
 ")
         echo "##vso[task.setvariable variable=$CVE_LIST_VAR_NAME]$TRIVY_CVES"
       fi

--- a/scanWithRetryTask.yml
+++ b/scanWithRetryTask.yml
@@ -141,18 +141,20 @@ steps:
           break
         else
           echo "Scan failed due to other errors."
-          ${{ if ne(parameters.vulnFoundVariableName, '') }}
-          echo "##vso[task.setvariable variable=${{ parameters.vulnFoundVariableName }}]true"
-          ${{ endif }}
+          VULN_VAR_NAME="${{ parameters.vulnFoundVariableName }}"
+          if [ -n "$VULN_VAR_NAME" ]; then
+            echo "##vso[task.setvariable variable=$VULN_VAR_NAME]true"
+          fi
           exit 1
         fi
       fi
     done
     if [ $count -eq $retries ]; then
       echo "Scan failed after $retries attempts due to DB download error."
-      ${{ if ne(parameters.vulnFoundVariableName, '') }}
-      echo "##vso[task.setvariable variable=${{ parameters.vulnFoundVariableName }}]true"
-      ${{ endif }}
+      VULN_VAR_NAME="${{ parameters.vulnFoundVariableName }}"
+      if [ -n "$VULN_VAR_NAME" ]; then
+        echo "##vso[task.setvariable variable=$VULN_VAR_NAME]true"
+      fi
       exit 1
     fi
   displayName: ${{ parameters.displayName }}

--- a/scanWithRetryTask.yml
+++ b/scanWithRetryTask.yml
@@ -39,6 +39,14 @@ parameters:
   type: string
   default: ''
   displayName: 'The Docker Hub registry connection (for authenticated pulls to avoid rate limits)'
+- name: continueOnError
+  type: boolean
+  default: false
+  displayName: 'Whether to continue the pipeline when vulnerabilities are found'
+- name: vulnFoundVariableName
+  type: string
+  default: ''
+  displayName: 'Pipeline variable name to set to "true" when vulnerabilities are found (used with continueOnError)'
 
 steps:
 - ${{ if ne(parameters.dockerhubRegistryConnection, '') }}:
@@ -133,12 +141,19 @@ steps:
           break
         else
           echo "Scan failed due to other errors."
+          ${{ if ne(parameters.vulnFoundVariableName, '') }}
+          echo "##vso[task.setvariable variable=${{ parameters.vulnFoundVariableName }}]true"
+          ${{ endif }}
           exit 1
         fi
       fi
     done
     if [ $count -eq $retries ]; then
       echo "Scan failed after $retries attempts due to DB download error."
+      ${{ if ne(parameters.vulnFoundVariableName, '') }}
+      echo "##vso[task.setvariable variable=${{ parameters.vulnFoundVariableName }}]true"
+      ${{ endif }}
       exit 1
     fi
   displayName: ${{ parameters.displayName }}
+  continueOnError: ${{ parameters.continueOnError }}

--- a/scanWithRetryTask.yml
+++ b/scanWithRetryTask.yml
@@ -173,7 +173,7 @@ steps:
     order = ['critical','high','medium','low']
     result = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
     print(', '.join(result))
-")
+    ")
             echo "##vso[task.setvariable variable=$SUMMARY_VAR_NAME]$TRIVY_SUMMARY"
           fi
           CVE_LIST_VAR_NAME="${{ parameters.cveListVariableName }}"
@@ -193,7 +193,7 @@ steps:
             seen.add(cve)
             results.append(cve + '|' + lib + '|' + ver + '|' + sev)
     print(';'.join(results))
-")
+    ")
             echo "##vso[task.setvariable variable=$CVE_LIST_VAR_NAME]$TRIVY_CVES"
           fi
           exit 1
@@ -226,7 +226,7 @@ steps:
     order = ['critical','high','medium','low']
     result = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
     print(', '.join(result))
-")
+    ")
         echo "##vso[task.setvariable variable=$SUMMARY_VAR_NAME]$TRIVY_SUMMARY"
       fi
       CVE_LIST_VAR_NAME="${{ parameters.cveListVariableName }}"
@@ -246,7 +246,7 @@ steps:
             seen.add(cve)
             results.append(cve + '|' + lib + '|' + ver + '|' + sev)
     print(';'.join(results))
-")
+    ")
         echo "##vso[task.setvariable variable=$CVE_LIST_VAR_NAME]$TRIVY_CVES"
       fi
       exit 1

--- a/scanWithRetryTask.yml
+++ b/scanWithRetryTask.yml
@@ -155,6 +155,8 @@ steps:
           fi
           SUMMARY_VAR_NAME="${{ parameters.summaryVariableName }}"
           if [ -n "$SUMMARY_VAR_NAME" ]; then
+            # Python code is at YAML block base indentation (4 spaces); YAML strips
+            # those spaces before bash runs, so Python receives correctly 0-indented code.
             TRIVY_SUMMARY=$(echo "$log_output" | python3 -c "
     import re, sys
     counts = {}
@@ -202,12 +204,10 @@ steps:
     done
     if [ $count -eq $retries ]; then
       echo "Scan failed after $retries attempts due to DB download error."
-      VULN_VAR_NAME="${{ parameters.vulnFoundVariableName }}"
-      if [ -n "$VULN_VAR_NAME" ]; then
-        echo "##vso[task.setvariable variable=$VULN_VAR_NAME]true"
-      fi
       SUMMARY_VAR_NAME="${{ parameters.summaryVariableName }}"
       if [ -n "$SUMMARY_VAR_NAME" ]; then
+        # Python code is at YAML block base indentation (4 spaces); YAML strips
+        # those spaces before bash runs, so Python receives correctly 0-indented code.
         TRIVY_SUMMARY=$(echo "$log_output" | python3 -c "
     import re, sys
     counts = {}

--- a/scanWithRetryTask.yml
+++ b/scanWithRetryTask.yml
@@ -51,6 +51,10 @@ parameters:
   type: string
   default: ''
   displayName: 'Pipeline variable name to set to a "N critical, N high, ..." string when vulnerabilities are found'
+- name: cveListVariableName
+  type: string
+  default: ''
+  displayName: 'Pipeline variable name to set to a semicolon-separated "CVE-ID|Library|Version|Severity" list when vulnerabilities are found'
 
 steps:
 - ${{ if ne(parameters.dockerhubRegistryConnection, '') }}:
@@ -172,6 +176,26 @@ print(', '.join(result))
 ")
             echo "##vso[task.setvariable variable=$SUMMARY_VAR_NAME]$TRIVY_SUMMARY"
           fi
+          CVE_LIST_VAR_NAME="${{ parameters.cveListVariableName }}"
+          if [ -n "$CVE_LIST_VAR_NAME" ]; then
+            TRIVY_CVES=$(echo "$log_output" | python3 -c "
+import re, sys
+results = []
+seen = set()
+for line in sys.stdin:
+    if '│' not in line:
+        continue
+    parts = [p.strip() for p in line.split('│')]
+    if len(parts) < 6:
+        continue
+    lib, cve, sev, ver = parts[1], parts[2], parts[3], parts[5]
+    if re.match(r'CVE-', cve) and re.match(r'CRITICAL|HIGH|MEDIUM|LOW', sev) and lib and cve not in seen:
+        seen.add(cve)
+        results.append(f'{cve}|{lib}|{ver}|{sev}')
+print(';'.join(results))
+")
+            echo "##vso[task.setvariable variable=$CVE_LIST_VAR_NAME]$TRIVY_CVES"
+          fi
           exit 1
         fi
       fi
@@ -204,6 +228,26 @@ result = [str(counts[s]) + ' ' + s for s in order if counts.get(s, 0) > 0]
 print(', '.join(result))
 ")
         echo "##vso[task.setvariable variable=$SUMMARY_VAR_NAME]$TRIVY_SUMMARY"
+      fi
+      CVE_LIST_VAR_NAME="${{ parameters.cveListVariableName }}"
+      if [ -n "$CVE_LIST_VAR_NAME" ]; then
+        TRIVY_CVES=$(echo "$log_output" | python3 -c "
+import re, sys
+results = []
+seen = set()
+for line in sys.stdin:
+    if '│' not in line:
+        continue
+    parts = [p.strip() for p in line.split('│')]
+    if len(parts) < 6:
+        continue
+    lib, cve, sev, ver = parts[1], parts[2], parts[3], parts[5]
+    if re.match(r'CVE-', cve) and re.match(r'CRITICAL|HIGH|MEDIUM|LOW', sev) and lib and cve not in seen:
+        seen.add(cve)
+        results.append(f'{cve}|{lib}|{ver}|{sev}')
+print(';'.join(results))
+")
+        echo "##vso[task.setvariable variable=$CVE_LIST_VAR_NAME]$TRIVY_CVES"
       fi
       exit 1
     fi


### PR DESCRIPTION
## Summary

- Add `scanReleasedImage.yml` step template: wraps pull, trivyIgnore→OpenVEX conversion, Docker Scout scan, and Trivy scan into a single reusable step per image
- Add `convertTrivyIgnoreToVex.yml` step template: extracts the trivyIgnore→OpenVEX PowerShell conversion previously duplicated inline in `scanDockerImage.yml` and `scanReleasedImage.yml`
- Extend `scanWithRetryTask.yml` with `continueOnError`, `vulnFoundVariableName`, `summaryVariableName`, and `cveListVariableName` parameters so Trivy results can be surfaced in Slack alerts
- Fix `scanDockerImage.yml`: Docker Scout was logging CVE findings but always exiting 0 — pipeline now fails correctly when Scout finds vulnerabilities
- Fix `convertTrivyIgnoreToVex.yml`: ADO does not support `condition` on step template references; condition is now a parameter applied to the internal task

## Test plan

- [x] Run Vonk/FA build pipeline pointing at this branch — verify Scout and Trivy steps complete and pipeline fails when CVEs are found
- [x] Run weekly scan pipeline (`docker-image-vulnerability-scan.yaml`) pointing at this branch — verify all four images are scanned and Slack notification is sent
- [ ] Merge this PR first, tag a new `v1`, then update `Vonk.Infrastructure` pipeline to point at `refs/tags/v1`