### PR TITLE
Fix Docker Scout VEX suppressions (product purl + vex-author)

### DIFF
--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -42,8 +42,8 @@ jobs:
     - name: docker_image_full_name
       value: ${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}:${{ parameters.dockerImageRepoVersion }}
     # Docker Scout matches a VEX statement's product @id against the image purl. For a
-    # registry-qualified image the purl is pkg:docker/<repo>@<tag>?repository_url=<registry-host>:
-    # the registry host is a `repository_url` qualifier, NOT part of the namespace path. Putting it
+    # registry-qualified image the purl is pkg:docker/<repo>@<tag>?repository_url=<registry-host>.
+    # The registry host is a `repository_url` qualifier, NOT part of the namespace path. Putting it
     # in the path (pkg:docker/<registry>/<repo>@<tag>) makes the product unmatchable so no VEX
     # statement is applied (see docker/scout-cli#207). Verified locally against a registry image.
     - name: docker_image_package_url

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -41,12 +41,13 @@ jobs:
       value: $[ ne('${{ parameters.dockerhubRegistryConnection }}', '') ]
     - name: docker_image_full_name
       value: ${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}:${{ parameters.dockerImageRepoVersion }}
-    # Docker Scout matches a VEX statement's product @id against the image purl, which does NOT
-    # include the registry host. Including ${{ parameters.dockerRegistryName }} here makes the
-    # product purl unmatchable, so no VEX statement is ever applied (see docker/scout-cli#207).
-    # Use pkg:docker/<repo>@<tag> to match Scout's image purl.
+    # Docker Scout matches a VEX statement's product @id against the image purl. For a
+    # registry-qualified image the purl is pkg:docker/<repo>@<tag>?repository_url=<registry-host>:
+    # the registry host is a `repository_url` qualifier, NOT part of the namespace path. Putting it
+    # in the path (pkg:docker/<registry>/<repo>@<tag>) makes the product unmatchable so no VEX
+    # statement is applied (see docker/scout-cli#207). Verified locally against a registry image.
     - name: docker_image_package_url
-      value: pkg:docker/${{ parameters.dockerImageRepoName }}@${{ parameters.dockerImageRepoVersion }}
+      value: pkg:docker/${{ parameters.dockerImageRepoName }}@${{ parameters.dockerImageRepoVersion }}?repository_url=${{ parameters.dockerRegistryName }}
 
   steps:
   - checkout: self

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -90,8 +90,11 @@ jobs:
         echo "Installing Docker Scout CLI to ${install_dir}"
         curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s -- -b ${install_dir}
         FAILED=0
+        # --vex-author must match the author written by convertTrivyIgnoreToVex.yml (devops@fire.ly).
+        # Docker Scout only honours VEX statements from accepted authors (default: <.*@docker.com>),
+        # so without this flag our not_affected statements are read but never applied.
         echo "Get a CVE report for the base image"
-        docker scout cves --vex-location vex.json --only-base ${{ variables['docker_image_full_name'] }} --exit-code --only-severity critical,high,medium,low
+        docker scout cves --vex-location vex.json --vex-author devops@fire.ly --only-base ${{ variables['docker_image_full_name'] }} --exit-code --only-severity critical,high,medium,low
         if [ $? -ne 0 ]; then
           echo "Vulnerabilities found in packages installed in the base image"
           FAILED=1
@@ -99,7 +102,7 @@ jobs:
           echo "No vulnerabilities found in packages installed in the base image"
         fi
         echo "Get a CVE report for the built image (without considering CVE from base image)"
-        docker scout cves --vex-location vex.json --ignore-base ${{ variables['docker_image_full_name'] }} --exit-code --only-severity critical,high,medium,low
+        docker scout cves --vex-location vex.json --vex-author devops@fire.ly --ignore-base ${{ variables['docker_image_full_name'] }} --exit-code --only-severity critical,high,medium,low
         if [ $? -ne 0 ]; then
           echo "Vulnerabilities found in packages installed in the image"
           FAILED=1

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -41,8 +41,12 @@ jobs:
       value: $[ ne('${{ parameters.dockerhubRegistryConnection }}', '') ]
     - name: docker_image_full_name
       value: ${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}:${{ parameters.dockerImageRepoVersion }}
+    # Docker Scout matches a VEX statement's product @id against the image purl, which does NOT
+    # include the registry host. Including ${{ parameters.dockerRegistryName }} here makes the
+    # product purl unmatchable, so no VEX statement is ever applied (see docker/scout-cli#207).
+    # Use pkg:docker/<repo>@<tag> to match Scout's image purl.
     - name: docker_image_package_url
-      value: pkg:docker/${{ parameters.dockerRegistryName }}/${{ parameters.dockerImageRepoName }}@${{ parameters.dockerImageRepoVersion }}
+      value: pkg:docker/${{ parameters.dockerImageRepoName }}@${{ parameters.dockerImageRepoVersion }}
 
   steps:
   - checkout: self


### PR DESCRIPTION
## Problem

`scanDockerImage.yml` runs `docker scout cves --vex-location vex.json`, with the VEX generated by `convertTrivyIgnoreToVex.yml` from `trivyIgnore.txt`. In practice **no VEX statement was ever applied** — Scout logged `Loaded 1 VEX document` but every suppressed CVE still surfaced and failed `--exit-code`. This surfaced now because the .NET 10 shared-framework false positives (`CVE-2026-40372`, `CVE-2026-33116`, `CVE-2026-26171`) and busybox `CVE-2025-60876` are the first real CVEs we tried to suppress via Scout; Trivy was unaffected because it matches by CVE id via `--ignorefile`.

Two independent bugs, both required to fix:

### 1. Product purl placed the registry host in the namespace path
The product `@id` was built as `pkg:docker/<registry>/<repo>@<tag>`. Docker Scout's image purl for a registry-qualified image is `pkg:docker/<repo>@<tag>?repository_url=<registry-host>` — the registry host is a `repository_url` **qualifier**, not part of the namespace path. With it in the path the product never matched the image, so no statement applied (cf. docker/scout-cli#207). Bare removal (`pkg:docker/<repo>@<tag>`) also fails against a registry image; the qualifier is required.

### 2. VEX author not accepted
`docker scout cves` only honours VEX statements whose author matches `--vex-author` (default `<.*@docker.com>`). Our document is authored `devops@fire.ly`, so even once the product matched, Scout read the statement and annotated the CVE `VEX: not affected` but **still counted it** and failed `--exit-code`. Pass `--vex-author devops@fire.ly` (matching `convertTrivyIgnoreToVex.yml`) on both scout invocations.

## Changes
- `docker_image_package_url` → `pkg:docker/<repo>@<tag>?repository_url=<registry>` (registry host moved to the `repository_url` qualifier).
- `--vex-author devops@fire.ly` added to both `docker scout cves` calls (`--only-base` and `--ignore-base`).

## Validation
Reproduced locally (docker scout 1.22.0) against `mcr.microsoft.com/dotnet/aspnet:8.0` (which has a base-image CVE): only the corrected purl **plus** the author flag yields exit 0, in both the `--only-base` and `--ignore-base` passes. Subcomponents are not needed; an invalid justification (`no_known_fix`) is tolerated.

Validated end-to-end on Firely CI (vonk PR #3200) with both pipelines pointed at this branch:
- **Firely Server image** (build 73424): base-image busybox + the three .NET CVEs all suppressed — scout step **succeeded**.
- **FSI image** (build 73423): base-image busybox suppressed — scout step **succeeded**.

After merge, move the `v1` tag to the merged commit; the vonk pipelines then revert their temporary `ref:` overrides back to `refs/tags/v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)