### PR TITLE
DEVOPS-724: add shared purgeAcrBuildImages job template

### DIFF
--- a/purgeAcrBuildImages.yml
+++ b/purgeAcrBuildImages.yml
@@ -1,0 +1,103 @@
+# Repo: FirelyTeam/azure-pipeline-templates
+# File: purgeAcrBuildImages.yml
+#
+# Called on release from each product's release flow. Keeps the just-released minor plus
+# `keepMinors` previous minors (within the released major) of build images, and purges
+# everything older. The keep-window is anchored on the released version itself (parsed from
+# `version`), not on whatever happens to already be tagged - so it doesn't depend on the
+# just-pushed build tag having shown up yet in `az acr repository show-tags`. Other majors,
+# and non-build tags (latest, stable, clean X.Y.Z, etc.), are never touched.
+
+parameters:
+- name: dependsOn
+  type: object
+  default: []
+  displayName: 'The name of the job that this job depends on'
+- name: azureServiceConnection
+  type: string
+  default: 'FHIR Test buildserver'
+  displayName: 'Azure service connection with access to the ACR (az acr repository/run commands)'
+- name: registry
+  type: string
+  default: 'firely'
+  displayName: 'The name of the Azure Container Registry (not the login server FQDN)'
+- name: imageRepository
+  type: string
+  displayName: 'The ACR repository to purge, e.g. firely/server, firely/fsi, firely/auth'
+- name: version
+  type: string
+  displayName: 'The version that was just released, e.g. $(CurrentVersion) or $(Version)'
+- name: keepMinors
+  type: number
+  default: 1
+  displayName: 'Number of previous minors (below the released one, within the released major) to also keep'
+- name: dryRun
+  type: boolean
+  default: false
+  displayName: 'List tags that would be purged without deleting anything'
+- name: condition
+  type: string
+  default: 'succeeded()'
+  displayName: 'Job condition - override when the calling stage/pipeline has no release-only gate of its own'
+- name: jobVariables
+  type: object
+  default: {}
+  displayName: 'Extra job-level variables to merge in, e.g. to resolve a same-stage output variable via dependencies.<job>.outputs[...] when no stage-level version variable exists'
+
+jobs:
+- job: purgeAcrBuildImages
+  displayName: 'Purge superseded build images (${{ parameters.imageRepository }})'
+  dependsOn: ${{ parameters.dependsOn }}
+  condition: ${{ parameters.condition }}
+  pool:
+    vmImage: 'ubuntu-latest'
+  variables:
+    ${{ insert }}: ${{ parameters.jobVariables }}
+  steps:
+  - task: AzureCLI@2
+    displayName: 'Purge older minors of the released major'
+    inputs:
+      azureSubscription: ${{ parameters.azureServiceConnection }}
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        $registry = '${{ parameters.registry }}'
+        $repo     = '${{ parameters.imageRepository }}'
+        $version  = '${{ parameters.version }}'
+        $keep     = [int]'${{ parameters.keepMinors }}'
+        $dryRun   = [System.Convert]::ToBoolean('${{ parameters.dryRun }}')
+
+        if ($version -notmatch '^(\d+)\.(\d+)\.') { Write-Error "Bad version '$version'"; exit 1 }
+        $major = [int]$Matches[1]
+        $releasedMinor = [int]$Matches[2]
+        $minKeptMinor = $releasedMinor - $keep
+        Write-Host "Release $version -> cleaning major $major line in $repo (keep minor $releasedMinor and the $keep minor(s) below it, i.e. minor >= $minKeptMinor)"
+
+        $tags = az acr repository show-tags --name $registry --repository $repo --output tsv
+        if ($LASTEXITCODE -ne 0) { Write-Error "Failed to list tags for $repo"; exit 1 }
+
+        # Only build tags of the released major: <major>.<minor>.<patch>-build-...
+        $builds = foreach ($t in $tags) {
+          if ($t -match "^$major\.(\d+)\.(\d+)-build-") {
+            [pscustomobject]@{ Tag = $t; Minor = [int]$Matches[1] }
+          }
+        }
+        if (-not $builds) { Write-Host "No build tags for major $major"; exit 0 }
+
+        $toDelete = $builds | Where-Object { $_.Minor -lt $minKeptMinor }
+        Write-Host "keep: $($builds.Count - $toDelete.Count)  delete: $($toDelete.Count)"
+
+        foreach ($b in $toDelete) {
+          if ($dryRun) {
+            Write-Host "[DRY RUN] would untag ${repo}:$($b.Tag)"
+          } else {
+            az acr repository untag --name $registry --image "${repo}:$($b.Tag)" | Out-Null
+          }
+        }
+
+        if (-not $dryRun -and $toDelete.Count -gt 0) {
+          Write-Host "Purging orphaned manifests left behind by the untag..."
+          az acr run --registry $registry `
+            --cmd "mcr.microsoft.com/acr/acr-cli:0.16 purge --filter '${repo}:^`$' --untagged --ago 0d" `
+            /dev/null
+        }

--- a/purgeAcrBuildImages.yml
+++ b/purgeAcrBuildImages.yml
@@ -7,6 +7,15 @@
 # `version`), not on whatever happens to already be tagged - so it doesn't depend on the
 # just-pushed build tag having shown up yet in `az acr repository show-tags`. Other majors,
 # and non-build tags (latest, stable, clean X.Y.Z, etc.), are never touched.
+#
+# Usage:
+#   - template: purgeAcrBuildImages.yml@templates
+#     parameters:
+#       dependsOn: deployDockerHub
+#       azureServiceConnection: 'FHIR Test buildserver'
+#       imageRepository: $(FIRELY_SERVER_IMAGE_REPO_NAME)
+#       version: $(CurrentVersion)
+#       dryRun: true # first release after rollout - flip off once the keep/delete list is verified
 
 parameters:
 - name: dependsOn
@@ -15,7 +24,6 @@ parameters:
   displayName: 'The name of the job that this job depends on'
 - name: azureServiceConnection
   type: string
-  default: 'FHIR Test buildserver'
   displayName: 'Azure service connection with access to the ACR (az acr repository/run commands)'
 - name: registry
   type: string
@@ -67,13 +75,14 @@ jobs:
         $keep     = [int]'${{ parameters.keepMinors }}'
         $dryRun   = [System.Convert]::ToBoolean('${{ parameters.dryRun }}')
 
+        if ($keep -lt 0) { Write-Error "keepMinors must be >= 0, got $keep"; exit 1 }
         if ($version -notmatch '^(\d+)\.(\d+)\.') { Write-Error "Bad version '$version'"; exit 1 }
         $major = [int]$Matches[1]
         $releasedMinor = [int]$Matches[2]
         $minKeptMinor = $releasedMinor - $keep
         Write-Host "Release $version -> cleaning major $major line in $repo (keep minor $releasedMinor and the $keep minor(s) below it, i.e. minor >= $minKeptMinor)"
 
-        $tags = az acr repository show-tags --name $registry --repository $repo --output tsv
+        $tags = @(az acr repository show-tags --name $registry --repository $repo --output tsv)
         if ($LASTEXITCODE -ne 0) { Write-Error "Failed to list tags for $repo"; exit 1 }
 
         # Only build tags of the released major: <major>.<minor>.<patch>-build-...
@@ -92,12 +101,14 @@ jobs:
             Write-Host "[DRY RUN] would untag ${repo}:$($b.Tag)"
           } else {
             az acr repository untag --name $registry --image "${repo}:$($b.Tag)" | Out-Null
+            if ($LASTEXITCODE -ne 0) { Write-Error "Failed to untag ${repo}:$($b.Tag)"; exit 1 }
           }
         }
 
         if (-not $dryRun -and $toDelete.Count -gt 0) {
-          Write-Host "Purging orphaned manifests left behind by the untag..."
+          Write-Host "Purging manifests orphaned by the untag operation above..."
           az acr run --registry $registry `
             --cmd "mcr.microsoft.com/acr/acr-cli:0.16 purge --filter '${repo}:^`$' --untagged --ago 0d" `
             /dev/null
+          if ($LASTEXITCODE -ne 0) { Write-Error "Orphaned manifest purge failed for $repo"; exit 1 }
         }


### PR DESCRIPTION
## Summary
- Adds a shared job template `purgeAcrBuildImages.yml` used by product release flows to clean up superseded ACR build images (`<version>-build-YYYYMMDD.N` tags) after each release.
- On release of `X.Y.Z`, keeps the released minor `X.Y.*` plus `keepMinors` previous minors (default `1`, i.e. also keeps `X.(Y-1).*`) within major `X`, and purges everything older in that major. Other majors, and non-build tags (`latest`, `stable`, clean `X.Y.Z`, etc.), are never touched.
- The keep-window is anchored on the released version itself (parsed from the `version` parameter), not on whatever tags already happen to exist in ACR — so it's correct even before the just-released build tag shows up in `az acr repository show-tags`.
- `dryRun` parameter lists tags that would be purged without deleting anything; consuming pipelines should set `dryRun: true` for their first release after wiring this in.

## Verification
- Verified the exact logic locally against real `firely/server` / `firely/fsi` ACR data (read-only, `dryRun` hardcoded) for both a next-minor release and a different-major release, confirming correct minor-boundary selection and major-line isolation.
- Ran the template directly on a live ADO agent via a throwaway pipeline (no release-tag gating, `dryRun: true`, simulated `version: 6.10.0` against the real `firely/server` repo) — output matched the local simulation exactly: kept `6.9.x` (179 tags), selected all `6.8.x` (307 tags) for deletion, no tags actually touched.

## Test plan
- [ ] Land this template, then wire it into one release flow first (Vonk Server 6.x) with `dryRun: true`
- [ ] Verify the real keep/delete list on that pipeline's first live release before flipping `dryRun` off
- [ ] Roll out to the remaining flows (Vonk Server 5.x, FSI 6.x/5.x, Firely.Auth)