### PR TITLE
Add opt-in license SBOM generation to scan templates (DEVOPS-772)

### DIFF
--- a/buildAndPushDockerImage.yml
+++ b/buildAndPushDockerImage.yml
@@ -33,6 +33,10 @@ parameters:
   type: string
   default: ''
   displayName: 'The Docker Hub registry connection (for authenticated pulls to avoid rate limits)'
+- name: generateSbom
+  type: boolean
+  default: false
+  displayName: 'Attach an SBOM + provenance attestation to the pushed image (docker buildx --sbom/--provenance). Retrievable via "docker buildx imagetools inspect" or "docker scout sbom".'
 
 jobs:
 - job: createDockerImage
@@ -75,12 +79,17 @@ jobs:
       docker run --privileged --rm tonistiigi/binfmt --install arm64
       docker run --privileged --rm tonistiigi/binfmt
       docker buildx create --use
-      if [ "${{ parameters.addLatestTag }}" = "True" ]; then 
+      attestArgs=""
+      if [ "${{ parameters.generateSbom }}" = "True" ]; then
+        attestArgs="--sbom=true --provenance=true"
+      fi
+      if [ "${{ parameters.addLatestTag }}" = "True" ]; then
         docker buildx build --platform linux/amd64,linux/arm64 \
           --build-arg=PUBLISHED_CODE=azuredevops \
           --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(Build.BuildNumber) \
           --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:latest \
           --push \
+          $attestArgs \
           --file ${{ parameters.dockerFile }} \
           $workingDir
       else
@@ -88,6 +97,7 @@ jobs:
           --build-arg=PUBLISHED_CODE=azuredevops \
           --tag ${{ parameters.dockerRegistry }}/${{ parameters.imageRepositoryName }}:$(Build.BuildNumber) \
           --push \
+          $attestArgs \
           --file ${{ parameters.dockerFile }} \
           $workingDir
       fi

--- a/check-skip-stage.yml
+++ b/check-skip-stage.yml
@@ -54,6 +54,9 @@ stages:
     steps:
     - checkout: self
       fetchDepth: 0
+    - template: ./getChangedFiles.yml
+      parameters:
+        name: getChangedFiles
     - powershell: |
         $patterns = '${{ convertToJson(parameters.ignorePatterns) }}' | ConvertFrom-Json
         $neverSkipRefPatterns = '${{ convertToJson(parameters.neverSkipRefPatterns) }}' | ConvertFrom-Json
@@ -78,21 +81,7 @@ stages:
         $patterns | ForEach-Object { Write-Host $_ }
         Write-Host "##[endgroup]"
 
-        if ($env:BUILD_REASON -eq 'PullRequest') {
-          # SYSTEM_PULLREQUEST_TARGETBRANCHNAME is the bare branch name (e.g. 'main'),
-          # whereas SYSTEM_PULLREQUEST_TARGETBRANCH is the full ref ('refs/heads/main')
-          # which would yield an invalid 'origin/refs/heads/main' ref.
-          Write-Host "PR build: diffing against origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCHNAME"
-          $changedFiles = @(git diff --name-only "origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCHNAME" | Where-Object { $_ })
-        }
-        else {
-          Write-Host "Branch build: diffing HEAD~1..HEAD"
-          $changedFiles = @(git diff --name-only HEAD~1 HEAD | Where-Object { $_ })
-        }
-
-        Write-Host "##[group]Changed files"
-        $changedFiles | ForEach-Object { Write-Host $_ }
-        Write-Host "##[endgroup]"
+        $changedFiles = @("$(getChangedFiles.changedFiles)" -split ';' | Where-Object { $_ })
 
         if (-not $changedFiles) {
           Write-Host "No changed files detected; not skipping."

--- a/checkRequiredFileChanges.yml
+++ b/checkRequiredFileChanges.yml
@@ -1,0 +1,107 @@
+# Repo: FirelyTeam/azure-pipeline-templates
+# File: checkRequiredFileChanges.yml
+#
+# Reusable job that inspects the changed files in the current build and sets an output variable
+# indicating whether any of them match a supplied set of "required" patterns. Useful for gating an
+# expensive job (e.g. a dependency/license scan) so it only runs when a relevant file actually
+# changed. This is the inverse of check-skip-stage.yml's ignorePatterns (skip if ALL changed files
+# match) - this is "changed=true if ANY changed file matches".
+#
+# Usage:
+#   - template: checkRequiredFileChanges.yml@templates
+#     parameters:
+#       jobName: checkLicenseDependencyChanges
+#       requiredPatterns:
+#         - '\.csproj$'
+#
+#   - job: scanLicenses
+#     dependsOn: checkLicenseDependencyChanges
+#     condition: eq(dependencies.checkLicenseDependencyChanges.outputs['evaluateChanges.changed'], 'true')
+
+parameters:
+- name: jobName
+  type: string
+  default: 'checkRequiredFileChanges'
+- name: displayName
+  type: string
+  default: 'Check for relevant file changes'
+- name: requiredPatterns
+  type: object
+  # List of PowerShell-style regex patterns. If at least one changed file matches at least one
+  # pattern, the job's `changed` output variable is set to 'true'.
+- name: neverSkipRefPatterns
+  type: object
+  default:
+    - '^refs/tags/v.*$'
+  # Same semantics as check-skip-stage.yml: if the current build's ref matches any of these, the
+  # `changed` output is forced to 'true' regardless of which files changed. Pass an empty list to
+  # disable. Defaults to version tags so release builds always run the gated job.
+- name: vmImage
+  type: string
+  default: 'ubuntu-latest'
+
+jobs:
+- job: ${{ parameters.jobName }}
+  displayName: ${{ parameters.displayName }}
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+  steps:
+  - checkout: self
+    fetchDepth: 0
+  - powershell: |
+      $patterns = '${{ convertToJson(parameters.requiredPatterns) }}' | ConvertFrom-Json
+      $neverSkipRefPatterns = '${{ convertToJson(parameters.neverSkipRefPatterns) }}' | ConvertFrom-Json
+
+      if ($neverSkipRefPatterns.Count -gt 0 -and $env:BUILD_SOURCEBRANCH) {
+        foreach ($refPattern in $neverSkipRefPatterns) {
+          if ($env:BUILD_SOURCEBRANCH -match $refPattern) {
+            Write-Host "Ref '$env:BUILD_SOURCEBRANCH' matches neverSkipRefPattern '$refPattern'; treating as changed."
+            Write-Host "##vso[task.setvariable variable=changed;isOutput=true]true"
+            exit 0
+          }
+        }
+      }
+
+      if ($patterns.Count -eq 0) {
+        Write-Host "No requiredPatterns supplied; changed is always 'true'."
+        Write-Host "##vso[task.setvariable variable=changed;isOutput=true]true"
+        exit 0
+      }
+
+      Write-Host "##[group]Required patterns"
+      $patterns | ForEach-Object { Write-Host $_ }
+      Write-Host "##[endgroup]"
+
+      if ($env:BUILD_REASON -eq 'PullRequest') {
+        # SYSTEM_PULLREQUEST_TARGETBRANCHNAME is the bare branch name (e.g. 'develop'), whereas
+        # SYSTEM_PULLREQUEST_TARGETBRANCH is the full ref which would yield an invalid
+        # 'origin/refs/heads/develop' ref.
+        Write-Host "PR build: diffing against origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCHNAME"
+        $changedFiles = @(git diff --name-only "origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCHNAME" | Where-Object { $_ })
+      }
+      else {
+        Write-Host "Branch build: diffing HEAD~1..HEAD"
+        $changedFiles = @(git diff --name-only HEAD~1 HEAD | Where-Object { $_ })
+      }
+
+      Write-Host "##[group]Changed files"
+      $changedFiles | ForEach-Object { Write-Host $_ }
+      Write-Host "##[endgroup]"
+
+      $changed = 'false'
+      foreach ($file in $changedFiles) {
+        foreach ($pattern in $patterns) {
+          if ($file -match $pattern) {
+            Write-Host "'$file' matches required pattern '$pattern'."
+            $changed = 'true'
+            break
+          }
+        }
+        if ($changed -eq 'true') { break }
+      }
+      if ($changed -eq 'false') {
+        Write-Host "No changed file matches any required pattern."
+      }
+      Write-Host "##vso[task.setvariable variable=changed;isOutput=true]$changed"
+    name: evaluateChanges
+    displayName: 'Evaluate required file changes'

--- a/checkRequiredFileChanges.yml
+++ b/checkRequiredFileChanges.yml
@@ -27,8 +27,10 @@ parameters:
   default: 'Check for relevant file changes'
 - name: requiredPatterns
   type: object
+  default: []
   # List of PowerShell-style regex patterns. If at least one changed file matches at least one
-  # pattern, the job's `changed` output variable is set to 'true'.
+  # pattern, the job's `changed` output variable is set to 'true'. Empty (the default) means
+  # always 'true' - see the script's own "No requiredPatterns supplied" branch.
 - name: neverSkipRefPatterns
   type: object
   default:

--- a/checkRequiredFileChanges.yml
+++ b/checkRequiredFileChanges.yml
@@ -48,6 +48,9 @@ jobs:
   steps:
   - checkout: self
     fetchDepth: 0
+  - template: ./getChangedFiles.yml
+    parameters:
+      name: getChangedFiles
   - powershell: |
       $patterns = '${{ convertToJson(parameters.requiredPatterns) }}' | ConvertFrom-Json
       $neverSkipRefPatterns = '${{ convertToJson(parameters.neverSkipRefPatterns) }}' | ConvertFrom-Json
@@ -72,21 +75,7 @@ jobs:
       $patterns | ForEach-Object { Write-Host $_ }
       Write-Host "##[endgroup]"
 
-      if ($env:BUILD_REASON -eq 'PullRequest') {
-        # SYSTEM_PULLREQUEST_TARGETBRANCHNAME is the bare branch name (e.g. 'develop'), whereas
-        # SYSTEM_PULLREQUEST_TARGETBRANCH is the full ref which would yield an invalid
-        # 'origin/refs/heads/develop' ref.
-        Write-Host "PR build: diffing against origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCHNAME"
-        $changedFiles = @(git diff --name-only "origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCHNAME" | Where-Object { $_ })
-      }
-      else {
-        Write-Host "Branch build: diffing HEAD~1..HEAD"
-        $changedFiles = @(git diff --name-only HEAD~1 HEAD | Where-Object { $_ })
-      }
-
-      Write-Host "##[group]Changed files"
-      $changedFiles | ForEach-Object { Write-Host $_ }
-      Write-Host "##[endgroup]"
+      $changedFiles = @("$(getChangedFiles.changedFiles)" -split ';' | Where-Object { $_ })
 
       $changed = 'false'
       foreach ($file in $changedFiles) {

--- a/getChangedFiles.yml
+++ b/getChangedFiles.yml
@@ -1,0 +1,46 @@
+# Repo: FirelyTeam/azure-pipeline-templates
+# File: getChangedFiles.yml
+#
+# Reusable step that computes the list of changed files for the current build - diffing against the
+# PR target branch, or HEAD~1 for a plain branch build - and exposes it as a semicolon-separated
+# output variable. Shared by check-skip-stage.yml and checkRequiredFileChanges.yml so the
+# PR-vs-branch-build diffing logic lives in exactly one place. Requires a preceding
+# `checkout: self` with `fetchDepth: 0` in the same job (a shallow clone can't diff against the
+# target branch or HEAD~1).
+#
+# Usage (within a job's steps):
+#   - template: getChangedFiles.yml
+#     parameters:
+#       name: getChangedFiles
+#
+#   - powershell: |
+#       $changedFiles = "$(getChangedFiles.changedFiles)" -split ';' | Where-Object { $_ }
+
+parameters:
+- name: name
+  type: string
+  default: 'getChangedFiles'
+  displayName: 'Step name, used to reference the changedFiles output variable'
+
+steps:
+- powershell: |
+    if ($env:BUILD_REASON -eq 'PullRequest') {
+      # SYSTEM_PULLREQUEST_TARGETBRANCHNAME is the bare branch name (e.g. 'develop'), whereas
+      # SYSTEM_PULLREQUEST_TARGETBRANCH is the full ref which would yield an invalid
+      # 'origin/refs/heads/develop' ref.
+      Write-Host "PR build: diffing against origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCHNAME"
+      $changedFiles = @(git diff --name-only "origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCHNAME" | Where-Object { $_ })
+    }
+    else {
+      Write-Host "Branch build: diffing HEAD~1..HEAD"
+      $changedFiles = @(git diff --name-only HEAD~1 HEAD | Where-Object { $_ })
+    }
+
+    Write-Host "##[group]Changed files"
+    $changedFiles | ForEach-Object { Write-Host $_ }
+    Write-Host "##[endgroup]"
+
+    $joined = $changedFiles -join ';'
+    Write-Host "##vso[task.setvariable variable=changedFiles;isOutput=true]$joined"
+  name: ${{ parameters.name }}
+  displayName: 'Get changed files'

--- a/scanBinaries.yml
+++ b/scanBinaries.yml
@@ -79,9 +79,22 @@ jobs:
         exitCode: '0'
         ignoredLicenses: ${{ parameters.licenseSbomIgnoredLicenses }}
         outputDir: $(Agent.TempDirectory)/trivy-sbom
+        # --exit-code 0 only suppresses the "findings" exit code - a genuine Trivy/Docker error (e.g. a
+        # transient pull failure) still exits non-zero. continueOnError keeps this strictly report-only.
+        continueOnError: true
+
+    - bash: |
+        if [ -f "$(Agent.TempDirectory)/trivy-sbom/sbom.json" ]; then
+          echo "##vso[task.setvariable variable=sbomFileExists]true"
+        else
+          echo "##vso[task.setvariable variable=sbomFileExists]false"
+        fi
+      displayName: Check license SBOM was generated
+      condition: succeededOrFailed()
 
     - task: PublishBuildArtifacts@1
       displayName: Publish license SBOM
+      condition: and(succeededOrFailed(), eq(variables['sbomFileExists'], 'true'))
       inputs:
         PathtoPublish: $(Agent.TempDirectory)/trivy-sbom/sbom.json
         ArtifactName: ${{ parameters.sbomArtifactName }}

--- a/scanBinaries.yml
+++ b/scanBinaries.yml
@@ -21,6 +21,18 @@ parameters:
   type: string
   default: ''
   displayName: 'The Docker Hub registry connection (for authenticated pulls to avoid rate limits)'
+- name: generateLicenseSbom
+  type: boolean
+  default: false
+  displayName: 'Also generate a CycloneDX SBOM (license scanner) and publish it as a build artifact. Never fails the build.'
+- name: licenseSbomIgnoredLicenses
+  type: string
+  default: ''
+  displayName: 'Comma-separated Trivy --ignored-licenses list for the SBOM scan (only used when generateLicenseSbom is true)'
+- name: sbomArtifactName
+  type: string
+  default: 'BinariesSBOM'
+  displayName: 'Artifact name for the published SBOM (only used when generateLicenseSbom is true)'
 
 jobs:
 - job: scan  
@@ -51,3 +63,25 @@ jobs:
       trivyCacheStorageAccount: ${{ parameters.trivyCacheStorageAccount }}
       localTrivyCachePath: $(Agent.TempDirectory)/trivy-cache
       dockerhubRegistryConnection: ${{ parameters.dockerhubRegistryConnection }}
+
+  - ${{ if eq(parameters.generateLicenseSbom, true) }}:
+    - template: ./scanWithRetryTask.yml
+      parameters:
+        dockerExtraArguments: "-v $(System.DefaultWorkingDirectory)/Binaries:/src"
+        trivyExtraArguments: "filesystem /src --output /mnt/trivy/output/sbom.json"
+        displayName: Generate license SBOM with Trivy
+        trivyCacheAzureSubscription: ${{ parameters.trivyCacheAzureSubscription }}
+        trivyCacheStorageAccount: ${{ parameters.trivyCacheStorageAccount }}
+        localTrivyCachePath: $(Agent.TempDirectory)/trivy-cache
+        dockerhubRegistryConnection: ${{ parameters.dockerhubRegistryConnection }}
+        scanners: license
+        format: cyclonedx
+        exitCode: '0'
+        ignoredLicenses: ${{ parameters.licenseSbomIgnoredLicenses }}
+        outputDir: $(Agent.TempDirectory)/trivy-sbom
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish license SBOM
+      inputs:
+        PathtoPublish: $(Agent.TempDirectory)/trivy-sbom/sbom.json
+        ArtifactName: ${{ parameters.sbomArtifactName }}

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -31,6 +31,18 @@ parameters:
   type: string
   default: ''
   displayName: 'The Docker Hub registry connection (required for scanning the image with docker scout)'
+- name: generateLicenseSbom
+  type: boolean
+  default: false
+  displayName: 'Also generate a CycloneDX SBOM (license scanner) and publish it as a build artifact. Never fails the build.'
+- name: licenseSbomIgnoredLicenses
+  type: string
+  default: ''
+  displayName: 'Comma-separated Trivy --ignored-licenses list for the SBOM scan (only used when generateLicenseSbom is true)'
+- name: sbomArtifactName
+  type: string
+  default: 'DockerImageSBOM'
+  displayName: 'Artifact name for the published SBOM (only used when generateLicenseSbom is true)'
 
 
 jobs:
@@ -122,6 +134,28 @@ jobs:
       trivyCacheStorageAccount: ${{ parameters.trivyCacheStorageAccount }}
       localTrivyCachePath: $(Agent.TempDirectory)/trivy-cache
       dockerhubRegistryConnection: ${{ parameters.dockerhubRegistryConnection }}
+
+  - ${{ if eq(parameters.generateLicenseSbom, true) }}:
+    - template: ./scanWithRetryTask.yml
+      parameters:
+        dockerExtraArguments: ""
+        trivyExtraArguments: "image ${{ variables['docker_image_full_name'] }} --output /mnt/trivy/output/sbom.json"
+        displayName: Generate license SBOM with Trivy
+        trivyCacheAzureSubscription: ${{ parameters.trivyCacheAzureSubscription }}
+        trivyCacheStorageAccount: ${{ parameters.trivyCacheStorageAccount }}
+        localTrivyCachePath: $(Agent.TempDirectory)/trivy-cache
+        dockerhubRegistryConnection: ${{ parameters.dockerhubRegistryConnection }}
+        scanners: license
+        format: cyclonedx
+        exitCode: '0'
+        ignoredLicenses: ${{ parameters.licenseSbomIgnoredLicenses }}
+        outputDir: $(Agent.TempDirectory)/trivy-sbom
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish license SBOM
+      inputs:
+        PathtoPublish: $(Agent.TempDirectory)/trivy-sbom/sbom.json
+        ArtifactName: ${{ parameters.sbomArtifactName }}
 
 #  The Trivy task does not work yet.
 #    - task: trivy@1

--- a/scanDockerImage.yml
+++ b/scanDockerImage.yml
@@ -150,9 +150,22 @@ jobs:
         exitCode: '0'
         ignoredLicenses: ${{ parameters.licenseSbomIgnoredLicenses }}
         outputDir: $(Agent.TempDirectory)/trivy-sbom
+        # --exit-code 0 only suppresses the "findings" exit code - a genuine Trivy/Docker error (e.g. a
+        # transient pull failure) still exits non-zero. continueOnError keeps this strictly report-only.
+        continueOnError: true
+
+    - bash: |
+        if [ -f "$(Agent.TempDirectory)/trivy-sbom/sbom.json" ]; then
+          echo "##vso[task.setvariable variable=sbomFileExists]true"
+        else
+          echo "##vso[task.setvariable variable=sbomFileExists]false"
+        fi
+      displayName: Check license SBOM was generated
+      condition: succeededOrFailed()
 
     - task: PublishBuildArtifacts@1
       displayName: Publish license SBOM
+      condition: and(succeededOrFailed(), eq(variables['sbomFileExists'], 'true'))
       inputs:
         PathtoPublish: $(Agent.TempDirectory)/trivy-sbom/sbom.json
         ArtifactName: ${{ parameters.sbomArtifactName }}

--- a/scanWithRetryTask.yml
+++ b/scanWithRetryTask.yml
@@ -55,6 +55,26 @@ parameters:
   type: string
   default: ''
   displayName: 'Pipeline variable name to set to a semicolon-separated "CVE-ID|Library|Version|Severity" list when vulnerabilities are found'
+- name: scanners
+  type: string
+  default: 'vuln,misconfig,secret'
+  displayName: 'Comma-separated Trivy --scanners list (vuln, misconfig, secret, license)'
+- name: format
+  type: string
+  default: 'table'
+  displayName: 'Trivy --format value (table, json, cyclonedx, spdx-json, ...)'
+- name: exitCode
+  type: string
+  default: '1'
+  displayName: 'Trivy --exit-code value. Use 0 for non-blocking scans, e.g. license/SBOM reporting'
+- name: ignoredLicenses
+  type: string
+  default: ''
+  displayName: 'Comma-separated Trivy --ignored-licenses list (only relevant when scanners includes license)'
+- name: outputDir
+  type: string
+  default: ''
+  displayName: 'Host directory to mount for Trivy --output file writes (mounted read-write at /mnt/trivy/output in the container - reference that path in trivyExtraArguments, e.g. "--output /mnt/trivy/output/sbom.json")'
 
 steps:
 - ${{ if ne(parameters.dockerhubRegistryConnection, '') }}:
@@ -131,8 +151,19 @@ steps:
       echo "Local cache is not empty, running in offline mode."
       offlineTrivyArgs="--skip-db-update --skip-java-db-update --offline-scan --skip-check-update"
     fi
-    
-    command="docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $ignoreMountArgs $localCacheMountArgs ${{ parameters.dockerExtraArguments }} aquasec/trivy:0.69.3 $ignoreFileTrivyArgs $localCacheTrivyArgs $offlineTrivyArgs --exit-code 1 --format table --scanners vuln,misconfig,secret ${{ parameters.trivyExtraArguments }}"
+
+    outputMountArgs=""
+    if [ -n "${{ parameters.outputDir }}" ]; then
+      mkdir -p "${{ parameters.outputDir }}"
+      outputMountArgs="-v ${{ parameters.outputDir }}:/mnt/trivy/output"
+    fi
+
+    ignoredLicensesTrivyArgs=""
+    if [ -n "${{ parameters.ignoredLicenses }}" ]; then
+      ignoredLicensesTrivyArgs="--ignored-licenses ${{ parameters.ignoredLicenses }}"
+    fi
+
+    command="docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $ignoreMountArgs $localCacheMountArgs $outputMountArgs ${{ parameters.dockerExtraArguments }} aquasec/trivy:0.69.3 $ignoreFileTrivyArgs $localCacheTrivyArgs $offlineTrivyArgs --exit-code ${{ parameters.exitCode }} --format ${{ parameters.format }} --scanners ${{ parameters.scanners }} $ignoredLicensesTrivyArgs ${{ parameters.trivyExtraArguments }}"
     
     echo "Executing '$command' with retries..."
     while [ $count -lt $retries ]; do


### PR DESCRIPTION
## What changed

**License SBOM generation for the ZIP/Docker image OS layer (opt-in, report-only):**
- Adds a report-only Trivy license-scanner/CycloneDX-SBOM pass to `scanBinaries.yml` and `scanDockerImage.yml`,
  gated behind a new `generateLicenseSbom` parameter (default `false`). Runs `--scanners license --format
  cyclonedx --exit-code 0` (never fails the build) and publishes the SBOM as a build artifact.
- `scanWithRetryTask.yml` parameterizes what was previously hardcoded (`--scanners`/`--format`/`--exit-code`),
  plus `outputDir` (mounts a host directory for `--output` file writes) and `ignoredLicenses`
  (`--ignored-licenses` pass-through - note this only affects Trivy's own `--exit-code` gating, not SBOM
  content; filtering against a product's allow-list happens downstream).
- Addressed Copilot review: `continueOnError: true` on the SBOM scan step (a genuine Trivy/Docker error can
  still exit non-zero even with `--exit-code 0`), and the publish step is guarded on the SBOM file existing.

**SBOM + provenance attestation for the Docker image itself:**
- New `generateSbom` parameter on `buildAndPushDockerImage.yml` (default `false`), appending
  `--sbom=true --provenance=true` to the existing `docker buildx build --push` command. BuildKit's own
  syft-based scanner generates a real SPDX SBOM and attaches it as an OCI attestation manifest - no new
  infrastructure, since `buildx --push` is already how images get pushed here. Retrievable via
  `docker buildx imagetools inspect --format '{{ json .SBOM }}'` or `docker scout sbom`.
- Verified twice: locally end-to-end against a throwaway registry (confirmed the attestation manifest exists
  and `{{ json .SBOM }}` returns a real SPDX document), and for real against ACR via the companion Vonk PR
  (build log shows `generating sbom using docker.io/docker/buildkit-syft-scanner` + a successful
  `exporting attestation manifest`).

**Dependency-change gating (new, reusable beyond this use case):**
- `checkRequiredFileChanges.yml`: a job template setting a `changed` output variable when any changed file
  matches a supplied pattern list - the inverse of `check-skip-stage.yml`'s ignore-pattern semantics.
- `getChangedFiles.yml`: extracted the PR-vs-branch-build git-diff logic (previously duplicated between
  `check-skip-stage.yml` and `checkRequiredFileChanges.yml`) into one shared step template both now call.
  `check-skip-stage.yml`'s external contract is unchanged - verified via a real build that this doesn't change
  its behavior, since it's already load-bearing in production (gates `stageBuild` for the main Vonk and FSI
  pipelines today).

## Backwards-compatible?

Yes throughout - every new parameter defaults to the prior hardcoded value or an empty/`false` no-op. The one
change to already-load-bearing code (`check-skip-stage.yml`'s internal refactor) keeps its external contract
(parameters, output variable name/shape) identical; verified via a real build (see companion PR's build 74506,
and the earlier build 74452 for this specific check).

## How it was tested

- YAML syntax validated for every file with `js-yaml`.
- Trivy SBOM invocation pattern run locally against `mcr.microsoft.com/dotnet/aspnet:10.0-alpine` (Vonk's real
  base image).
- Docker `--sbom`/`--provenance` run locally against a throwaway registry, and for real against ACR via the
  companion Vonk PR's branch pointing its `templates` ref here.
- Multiple real Azure DevOps builds triggered against consumer branches confirmed, on real agents: SBOM
  generation for both the ZIP and Docker image, `checkRequiredFileChanges.yml`'s evaluation logic, and
  `check-skip-stage.yml`'s unchanged behavior after the `getChangedFiles.yml` extraction.

## Tag bump

Purely additive, non-breaking change under the existing `v1` contract - once merged, `v1` should be retagged
(no new major tag needed). I have push access but am not retagging `v1` myself since it's a shared tag every
consumer pipeline is pinned to - flagging for whoever owns that step to do after reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)