### PR TITLE
Add runTests and checkForPrereleasePackages parameters to build.yml (DEVOPS-836)

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -56,6 +56,14 @@ parameters:
 - name: testFilter
   type: string
   default: '' # filter for unit tests; all tests by default
+- name: runTests
+  type: boolean
+  default: true
+  displayName: 'Whether to run dotnet test. Set to false for repos with no test project - a testProjects glob matching zero projects fails the test step with "Project file(s) matching the specified pattern were not found".'
+- name: checkForPrereleasePackages
+  type: boolean
+  default: false
+  displayName: 'Whether to fail the build if any internal (Simplifier.*/Firely.*/Hl7.Fhir.*) PackageReference points at a prerelease version. Third-party prerelease dependencies are not affected.'
 - name: numberOfDaysRetainmentForReleaseBuild
   type: number
   default: 365 # number of days to retain the build
@@ -129,6 +137,9 @@ jobs:
 
   # Run pre-build steps
   - ${{ parameters.preBuildSteps }}
+
+  - ${{ if parameters.checkForPrereleasePackages }}:
+    - template: check-for-prerelease-packages.yml
 
   ## retrieve the version suffix from the props file and set it as a variable
   - powershell: |
@@ -237,21 +248,22 @@ jobs:
         # pipelines (deploy) can use resources.pipeline.build.runName as the image tag.
         Write-Host "##vso[build.updatebuildnumber]${versionPrefix}-$(Build.BuildNumber)"
 
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet test UnitTests with filter'
-    condition: and(succeeded(), ne('${{ parameters.testFilter }}', ''))
-    inputs:
-      command: test
-      projects: ${{ parameters.testProjects }}
-      arguments: '--configuration $(buildConfiguration) --no-restore  --no-build --filter ${{ parameters.testFilter }}'
+  - ${{ if parameters.runTests }}:
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet test UnitTests with filter'
+      condition: and(succeeded(), ne('${{ parameters.testFilter }}', ''))
+      inputs:
+        command: test
+        projects: ${{ parameters.testProjects }}
+        arguments: '--configuration $(buildConfiguration) --no-restore  --no-build --filter ${{ parameters.testFilter }}'
 
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet test UnitTests'
-    condition: and(succeeded(), eq('${{ parameters.testFilter }}', ''))
-    inputs:
-      command: test
-      projects: ${{ parameters.testProjects }}
-      arguments: '--configuration $(buildConfiguration) --no-restore  --no-build'
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet test UnitTests'
+      condition: and(succeeded(), eq('${{ parameters.testFilter }}', ''))
+      inputs:
+        command: test
+        projects: ${{ parameters.testProjects }}
+        arguments: '--configuration $(buildConfiguration) --no-restore  --no-build'
 
   - template: strongNameSigning.yml
     parameters:

--- a/build.yml
+++ b/build.yml
@@ -59,11 +59,15 @@ parameters:
 - name: runTests
   type: boolean
   default: true
-  displayName: 'Whether to include the dotnet test steps in the build. Set to false to omit them entirely (e.g. for repos with no test project), rather than relying on testProjects to glob-match zero projects, which is unreliable across MSBuild/task versions.'
+  displayName: 'If false, the dotnet test steps are left out of the job entirely. Use for repos with no test project: a testProjects glob matching nothing only warns and passes, so tests would silently never run.'
 - name: checkForPrereleasePackages
   type: boolean
   default: false
-  displayName: 'Whether to fail the build if any internal (Simplifier.*/Firely.*/Hl7.Fhir.*) PackageReference points at a prerelease version. Third-party prerelease dependencies are not affected.'
+  displayName: 'If true, fail the build when a PackageReference covered by prereleasePackagePrefixes points at a prerelease version'
+- name: prereleasePackagePrefixes
+  type: string
+  default: 'Simplifier.,Firely.,Hl7.Fhir'
+  displayName: 'Comma-separated package name prefixes the prerelease check applies to. Empty checks every package, including third-party ones.'
 - name: numberOfDaysRetainmentForReleaseBuild
   type: number
   default: 365 # number of days to retain the build
@@ -140,6 +144,8 @@ jobs:
 
   - ${{ if parameters.checkForPrereleasePackages }}:
     - template: check-for-prerelease-packages.yml
+      parameters:
+        packagePrefixes: ${{ parameters.prereleasePackagePrefixes }}
 
   ## retrieve the version suffix from the props file and set it as a variable
   - powershell: |

--- a/build.yml
+++ b/build.yml
@@ -59,7 +59,7 @@ parameters:
 - name: runTests
   type: boolean
   default: true
-  displayName: 'Whether to run dotnet test. Set to false for repos with no test project - a testProjects glob matching zero projects fails the test step with "Project file(s) matching the specified pattern were not found".'
+  displayName: 'Whether to include the dotnet test steps in the build. Set to false to omit them entirely (e.g. for repos with no test project), rather than relying on testProjects to glob-match zero projects, which is unreliable across MSBuild/task versions.'
 - name: checkForPrereleasePackages
   type: boolean
   default: false

--- a/check-for-prerelease-packages.yml
+++ b/check-for-prerelease-packages.yml
@@ -1,26 +1,70 @@
 # Repo: FirelyTeam/azure-pipeline-templates
 # File: check-for-prerelease-packages.yml
 #
-# Fails the build if any PackageReference to an internal Firely/Simplifier/HL7 FHIR
-# package (name prefix Simplifier., Firely. or Hl7.Fhir.) points at a prerelease
-# version (a version containing a hyphen, e.g. 6.0.0-alpha1). Third-party prerelease
-# dependencies (e.g. Console.Routing 3.1.0-beta5) are intentionally not flagged -
-# only an accidental prerelease pin on one of our own packages should block a
-# release build.
+# Fails the build if a PackageReference points at a prerelease version (a version
+# containing a hyphen, e.g. 6.0.0-alpha1). By default every package is checked, which
+# is the historical behaviour. Set packagePrefixes to restrict the check to your own
+# packages, so that legitimate third-party prerelease dependencies (e.g.
+# Console.Routing 3.1.0-beta5) don't block a release build while an accidental
+# prerelease pin on one of our own packages still does.
+#
+# Versions written as an MSBuild property reference (Version="$(SimplifierBclVersion)")
+# are resolved from the PropertyGroups of the repo's .props and .csproj files, so the
+# check still works in repos that centralise their dependency versions that way.
 #
 # Usage (included internally by build.yml when checkForPrereleasePackages: true;
 # can also be referenced directly):
 #   steps:
 #     - template: check-for-prerelease-packages.yml@templates
+#       parameters:
+#         packagePrefixes: 'Simplifier.,Firely.,Hl7.Fhir'
+
+parameters:
+- name: packagePrefixes
+  type: string
+  default: ''
+  displayName: 'Comma-separated package name prefixes to restrict the check to, e.g. "Simplifier.,Firely.,Hl7.Fhir". Empty (the default) checks every package.'
 
 steps:
   - powershell: |
-        $internalPackagePrefixes = @('Simplifier.', 'Firely.', 'Hl7.Fhir.')
-        $projectFiles = @(Get-ChildItem -Recurse -Filter "*.csproj")
+        [string]$prefixParam = '${{ parameters.packagePrefixes }}'
+        $packagePrefixes = @($prefixParam -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+        $scopeDescription = if ($packagePrefixes.Count -gt 0) { ($packagePrefixes -join '*/') + '*' } else { 'all' }
+
+        Write-Host "Checking for prerelease versions of $scopeDescription packages."
+
+        # Collect MSBuild properties so that Version="$(SomeVersion)" can be resolved.
+        # Later definitions win, which is close enough to MSBuild's own last-one-wins
+        # semantics for the purpose of spotting a prerelease pin.
+        $isGeneratedPath = { param($path) $path -match '[\\/](bin|obj)[\\/]' }
+
+        $propertyValues = @{}
+        $propertyFiles = @(Get-ChildItem -Recurse -Include '*.props', '*.targets', '*.csproj' |
+            Where-Object { -not (& $isGeneratedPath $_.FullName) })
+        foreach ($propertyFile in $propertyFiles) {
+            try {
+                $xml = [xml](Get-Content -Raw -LiteralPath $propertyFile.FullName)
+            } catch {
+                Write-Host "##[warning]Could not parse $($propertyFile.FullName) as XML, skipping property collection for it: $($_.Exception.Message)"
+                continue
+            }
+
+            foreach ($propertyGroup in @($xml.Project.PropertyGroup)) {
+                if ($null -eq $propertyGroup) { continue }
+                foreach ($property in @($propertyGroup.ChildNodes)) {
+                    if ($property.NodeType -eq 'Element') {
+                        $propertyValues[$property.LocalName] = $property.InnerText
+                    }
+                }
+            }
+        }
+
         $hasPrerelease = $false
+        $projectFiles = @(Get-ChildItem -Recurse -Filter '*.csproj' |
+            Where-Object { -not (& $isGeneratedPath $_.FullName) })
 
         foreach ($project in $projectFiles) {
-            $content = Get-Content $project.FullName
+            $content = Get-Content -LiteralPath $project.FullName
             $packageRefLines = $content | Select-String -Pattern '<PackageReference\b[^>]*>'
 
             foreach ($line in $packageRefLines) {
@@ -34,20 +78,35 @@ steps:
 
                 $packageName = $nameMatch.Groups[1].Value
                 $packageVersion = $versionMatch.Groups[1].Value
-                $isInternal = @($internalPackagePrefixes | Where-Object { $packageName.StartsWith($_, [System.StringComparison]::OrdinalIgnoreCase) }).Count -gt 0
+
+                # Resolve a single level of $(Property) indirection.
+                $propertyReference = [regex]::Match($packageVersion, '^\s*\$\(([^)]+)\)\s*$')
+                if ($propertyReference.Success) {
+                    $propertyName = $propertyReference.Groups[1].Value
+                    if ($propertyValues.ContainsKey($propertyName)) {
+                        $packageVersion = $propertyValues[$propertyName]
+                    } else {
+                        Write-Host "##[warning]$($project.Name): could not resolve version property $propertyName for $packageName, skipping."
+                        continue
+                    }
+                }
+
+                $inScope = $packagePrefixes.Count -eq 0 -or
+                    @($packagePrefixes | Where-Object { $packageName.StartsWith($_, [System.StringComparison]::OrdinalIgnoreCase) }).Count -gt 0
                 $isPrerelease = $packageVersion -match '-'
 
-                if ($isInternal -and $isPrerelease) {
-                    Write-Host "Prerelease internal package found in $($project.Name): $packageName $packageVersion"
+                if ($inScope -and $isPrerelease) {
+                    Write-Host "##[error]Prerelease package found in $($project.Name): $packageName $packageVersion"
                     $hasPrerelease = $true
                 }
             }
         }
 
         if ($hasPrerelease) {
+            Write-Host "##[error]Release build blocked: one or more prerelease package references found (see above)."
             exit 1
         }
         else {
-            Write-Host "No prerelease internal (Simplifier.*/Firely.*/Hl7.Fhir.*) packages found in project files."
+            Write-Host "No prerelease $scopeDescription packages found in project files."
         }
-    displayName: 'Check for prerelease internal packages in project files'
+    displayName: 'Check for prerelease packages in project files'

--- a/check-for-prerelease-packages.yml
+++ b/check-for-prerelease-packages.yml
@@ -1,20 +1,46 @@
+# Repo: FirelyTeam/azure-pipeline-templates
+# File: check-for-prerelease-packages.yml
+#
+# Fails the build if any PackageReference to an internal Firely/Simplifier/HL7 FHIR
+# package (name prefix Simplifier., Firely. or Hl7.Fhir.) points at a prerelease
+# version (a version containing a hyphen, e.g. 6.0.0-alpha1). Third-party prerelease
+# dependencies (e.g. Console.Routing 3.1.0-beta5) are intentionally not flagged -
+# only an accidental prerelease pin on one of our own packages should block a
+# release build.
+#
+# Usage (included internally by build.yml when checkForPrereleasePackages: true;
+# can also be referenced directly):
+#   steps:
+#     - template: check-for-prerelease-packages.yml@templates
 
 steps:
   - powershell: |
-        $projectFiles = Get-ChildItem -Recurse -Filter "*.csproj"
+        $internalPackagePrefixes = @('Simplifier.', 'Firely.', 'Hl7.Fhir.')
+        $projectFiles = @(Get-ChildItem -Recurse -Filter "*.csproj")
         $hasPrerelease = $false
+
         foreach ($project in $projectFiles) {
             $content = Get-Content $project.FullName
-            $packageRefs = $content | Select-String -Pattern '<PackageReference.*Version=".*-.*"'
-            
-            if ($packageRefs) {
-                Write-Host "Prerelease packages found in $($project.Name)"
-                try{
-                    $packageRefs | ForEach-Object { Write-Host $_.Line.Trim() }
-                } catch {
-                    Write-Host "Error processing package references in $($project.Name): $_"
+            $packageRefLines = $content | Select-String -Pattern '<PackageReference\b[^>]*>'
+
+            foreach ($line in $packageRefLines) {
+                $tag = $line.Line
+                $nameMatch = [regex]::Match($tag, 'Include\s*=\s*"([^"]+)"')
+                $versionMatch = [regex]::Match($tag, 'Version\s*=\s*"([^"]+)"')
+
+                if (-not $nameMatch.Success -or -not $versionMatch.Success) {
+                    continue
                 }
-                $hasPrerelease = $true
+
+                $packageName = $nameMatch.Groups[1].Value
+                $packageVersion = $versionMatch.Groups[1].Value
+                $isInternal = @($internalPackagePrefixes | Where-Object { $packageName.StartsWith($_) }).Count -gt 0
+                $isPrerelease = $packageVersion -match '-'
+
+                if ($isInternal -and $isPrerelease) {
+                    Write-Host "Prerelease internal package found in $($project.Name): $packageName $packageVersion"
+                    $hasPrerelease = $true
+                }
             }
         }
 
@@ -22,8 +48,6 @@ steps:
             exit 1
         }
         else {
-            Write-Host "No pre-release packages found in project files."
+            Write-Host "No prerelease internal (Simplifier.*/Firely.*/Hl7.Fhir.*) packages found in project files."
         }
-    displayName: 'Check for pre-release packages in project files'
-
-  
+    displayName: 'Check for prerelease internal packages in project files'

--- a/check-for-prerelease-packages.yml
+++ b/check-for-prerelease-packages.yml
@@ -25,8 +25,8 @@ steps:
 
             foreach ($line in $packageRefLines) {
                 $tag = $line.Line
-                $nameMatch = [regex]::Match($tag, 'Include\s*=\s*"([^"]+)"')
-                $versionMatch = [regex]::Match($tag, 'Version\s*=\s*"([^"]+)"')
+                $nameMatch = [regex]::Match($tag, '(?:Include|Update)\s*=\s*"([^"]+)"')
+                $versionMatch = [regex]::Match($tag, '(?:VersionOverride|Version)\s*=\s*"([^"]+)"')
 
                 if (-not $nameMatch.Success -or -not $versionMatch.Success) {
                     continue
@@ -34,7 +34,7 @@ steps:
 
                 $packageName = $nameMatch.Groups[1].Value
                 $packageVersion = $versionMatch.Groups[1].Value
-                $isInternal = @($internalPackagePrefixes | Where-Object { $packageName.StartsWith($_) }).Count -gt 0
+                $isInternal = @($internalPackagePrefixes | Where-Object { $packageName.StartsWith($_, [System.StringComparison]::OrdinalIgnoreCase) }).Count -gt 0
                 $isPrerelease = $packageVersion -match '-'
 
                 if ($isInternal -and $isPrerelease) {


### PR DESCRIPTION
## What changed
- Added `runTests` parameter (boolean, default `true`) to `build.yml`. When `false`, both `dotnet test` steps are compile-time excluded entirely (not just skipped). This lets repos with no test project (e.g. Firely.YamlGen, DEVOPS-840) opt out, instead of relying on a `testProjects` glob that matches zero projects - which silently *passes* rather than failing (confirmed against Simplifier.Bcl build 76344).
- Added `checkForPrereleasePackages` parameter (boolean, default `false`) to `build.yml`. When `true`, conditionally includes `check-for-prerelease-packages.yml` internally, right after `preBuildSteps` and before the version-suffix steps (fails fast). A `template:` reference can't be passed as the value of the stepList-typed `preBuildSteps` parameter, so this is wired in directly rather than left to consumers to include themselves.
- Rescoped `check-for-prerelease-packages.yml` to only flag prerelease versions of internal packages (`Simplifier.*`, `Firely.*`, `Hl7.Fhir.*`). Previously it matched *any* prerelease `PackageReference`, which would incorrectly block release builds that have legitimate third-party prerelease dependencies (e.g. `Console.Routing 3.1.0-beta5` in Firely.QueryLanguage).

## Backwards compatibility
Fully backwards compatible for all current v1 consumers. Both new parameters default to values that preserve existing behavior exactly (`runTests: true` runs tests as before; `checkForPrereleasePackages: false` means the check is not run at all, same as before it existed as an opt-in). No existing parameter, default, or output was changed or removed.

## How it was tested
Validated end-to-end with two real ADO builds against Simplifier.QualityControl (pipeline definition 241), using a throwaway branch (`test/DEVOPS-836-template-validation`, deleted after testing - the actual PR #12 branch was never touched) with the template `ref:` temporarily pointed at `refs/heads/feature/DEVOPS-836-runtests-and-prerelease-check`:
- Build [76462](https://dev.azure.com/firely/Simplifier/_build/results?buildId=76462): `checkForPrereleasePackages: true` - the new step ran and passed (no internal prerelease packages in this repo).
- Build [76463](https://dev.azure.com/firely/Simplifier/_build/results?buildId=76463): `runTests: false` combined with a deliberately broken `testProjects` glob - both `dotnet test` steps were entirely absent from the timeline (not just skipped) and the build still succeeded through pack/deploy, proving the skip works at compile time.

Note: these two validation builds incidentally pushed two harmless build-numbered prerelease packages (`10.0.1-20260805.2` / `.3`) to the real `Simplifier.QualityControl`/`Simplifier.QualityControl.Fhir` GitHub Packages feeds (the deploy stage in that repo's pipeline is only gated on "not a PR build", not on branch). These won't collide with any real release version and are harmless, but couldn't be deleted afterwards - my `gh` token lacks the `delete:packages` scope. Flagging in case someone with package admin rights wants to tidy them up.

## Retagging
This repo tags releases (`v1`, `v2`...) rather than using a moving `main`/`master` ref. Once this PR is reviewed and merged, `v1` needs to be force-moved to the new `main` HEAD (`git tag -f v1 main && git push origin v1 --force`) for existing pinned consumers to pick up these additive changes. I have **not** done this and have **not** merged this PR myself - leaving both for team review/action per DEVOPS-818 workflow.

Refs: DEVOPS-836