### PR TITLE
Make updatePackageVersion XPath namespace-agnostic (DEVOPS-857)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,7 +77,20 @@ and backwards-compatibility are paramount.
   `ref: refs/heads/feature/DEVOPS-XXX-...`) and running a real CI build.
   **Revert the ref to a tag before merging the consumer's PR.**
 - Once merged to `main`, retag (`git tag -f v1 main`) so consumers
-  pinned to `v1` pick up the change.
+  pinned to `v1` pick up the change. Follow the **archive-then-move**
+  convention: snapshot the current `v1` as the next `v1-old<N>` tag
+  (a rollback point) *before* force-moving `v1`, then push both:
+  ```sh
+  git tag v1-old<N> v1       # archive current v1 (use the next free N)
+  git tag -f v1 main         # move v1 to the merged commit
+  git push origin v1-old<N>
+  git push --force origin v1
+  ```
+  Find the next `N` with `git tag --list 'v1-old*' | sed 's/v1-old//' | sort -n | tail -1`.
+- **Retag deliberately.** `v1` may lag `main` by several PRs, so moving it
+  ships *every* change merged since the last retag — not just yours — to all
+  consumers at once. Confirm the full delta (`git log v1..main --oneline`)
+  before retagging.
 
 ## PowerShell inside templates
 

--- a/updatePackageVersion.yml
+++ b/updatePackageVersion.yml
@@ -94,12 +94,12 @@ steps:
     # Load the XML
     [xml]$xml = Get-Content $xmlFilePath
 
-    # Define the XML namespace (since the XML file has a namespace)
-    $namespace = New-Object Xml.XmlNamespaceManager($xml.NameTable)
-    $namespace.AddNamespace("msb", "http://schemas.microsoft.com/developer/msbuild/2003")
-
-    # Find the package property element and update it
-    $packageVersionNode = $xml.SelectSingleNode("//msb:PropertyGroup/msb:${{ parameters.packageProperty }}", $namespace)
+    # Find the package property element and update it.
+    # Match on local-name() so the XPath is namespace-agnostic: it works both for
+    # legacy .props files that declare the MSBuild 2003 namespace on <Project> and
+    # for SDK-style files (e.g. Directory.Packages.props under Central Package
+    # Management) that have no XML namespace.
+    $packageVersionNode = $xml.SelectSingleNode("//*[local-name()='PropertyGroup']/*[local-name()='${{ parameters.packageProperty }}']")
     if ($null -ne $packageVersionNode) {
         $packageVersionNode.InnerText = $packageVersion
         # Save the updated XML back to the file


### PR DESCRIPTION
## What changed
- `updatePackageVersion.yml`: the property lookup now uses a namespace-agnostic XPath (`//*[local-name()='PropertyGroup']/*[local-name()='<property>']`) instead of the MSBuild-2003 namespace-qualified `//msb:PropertyGroup/msb:<property>`. The `XmlNamespaceManager` block is removed.
- `.github/copilot-instructions.md`: documented the **archive-then-move** retag convention (`v1-old<N>` snapshot before `git tag -f v1 main`) and a "retag deliberately" caveat, since these were only implied by tag history before.

## Why
The Vonk *FS Nightly Builds For Regression SDK* pipeline began failing at the *Update Firely SDK version* step with `FhirNetApiVersion element not found!`. Vonk repointed the template from `src/Vonk.props` (legacy, declares the MSBuild 2003 namespace on `<Project>`) to `Directory.Packages.props` (SDK-style Central Package Management, **no** XML namespace). The old namespaced XPath matched nothing in the namespace-free file, so the property was never found and the step exited 1.

`local-name()` matches elements regardless of namespace, so it works for both file styles.

## Backwards compatibility
**Non-breaking.** Inputs, outputs, and side effects are unchanged; the XPath is only broadened. Legacy namespaced `.props` files (e.g. `src/Vonk.props`, still used by other consumers) continue to match, and SDK-style files now match too.

## Testing
- Local `pwsh` check of the new XPath against both a namespaced `.props` and an SDK-style `Directory.Packages.props` — both matched and updated.
- End-to-end: Vonk regression pipeline run [#76800](https://dev.azure.com/firely/vonk/_build/results?buildId=76800) pointed at this feature branch — the *Update Firely SDK version* step is now green and the pipeline proceeds past it. (The later Restore failure in that run is an unrelated Vonk product-dependency issue — new SDK needs `Fhir.Metrics >= 1.4.0` — not a template problem.)

## Tagging
Requires a **retag of `v1`** after merge for consumers to pick it up (see the archive-then-move convention added to `.github/copilot-instructions.md`). No new major tag needed — the change is backwards-compatible.